### PR TITLE
fix: Fixed loosing changes after updating the ingredients or garnishes in cocktail form

### DIFF
--- a/components/cocktails/CocktailRecipeForm.tsx
+++ b/components/cocktails/CocktailRecipeForm.tsx
@@ -65,23 +65,22 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
     if (!workspaceId) return;
 
     setIngredientsLoading(true);
-    fetch(`/api/workspaces/${workspaceId}/ingredients`)
-      .then(async (response) => {
-        const body = await response.json();
-        if (response.ok) {
-          setIngredients(body.data);
-        } else {
-          console.error('CocktailRecipeForm -> fetchIngredients', response);
-          alertService.error(body.message ?? 'Fehler beim Laden der Zutaten', response.status, response.statusText);
-        }
-      })
-      .catch((error) => {
-        console.error('CocktailRecipeForm -> fetchIngredients', error);
-        alertService.error('Fehler beim Laden der Zutaten');
-      })
-      .finally(() => {
-        setIngredientsLoading(false);
-      });
+    try {
+      const response = await fetch(`/api/workspaces/${workspaceId}/ingredients`);
+
+      const body = await response.json();
+      if (response.ok) {
+        setIngredients(body.data);
+      } else {
+        console.error('CocktailRecipeForm -> fetchIngredients', response);
+        alertService.error(body.message ?? 'Fehler beim Laden der Zutaten', response.status, response.statusText);
+      }
+    } catch (error) {
+      console.error('CocktailRecipeForm -> fetchIngredients', error);
+      alertService.error('Fehler beim Laden der Zutaten');
+    } finally {
+      setIngredientsLoading(false);
+    }
   }, [workspaceId]);
 
   const openIngredientSelectModal = useCallback(
@@ -184,13 +183,6 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
       });
   }, [workspaceId]);
 
-  useEffect(() => {
-    fetchActions();
-    fetchGarnishes();
-    fetchIngredients();
-    fetchGlasses();
-  }, [fetchGarnishes, fetchGlasses, fetchIngredients]);
-
   const openGarnishSelectModal = useCallback(
     (setFieldValue: any, indexGarnish: number) => {
       modalContext.openModal(
@@ -224,13 +216,26 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
   }, [glasses, props.cocktailRecipe?.glassId]);
 
   useEffect(() => {
-    if (props.cocktailRecipe != undefined && props.cocktailRecipe.garnishes?.length > 0 && garnishes.length > 0) {
+    // Otherwise not saved changes will be overwritten
+    if (formRef.current?.values.garnishes == undefined) {
+      if (props.cocktailRecipe != undefined && props.cocktailRecipe.garnishes?.length > 0 && garnishes.length > 0) {
+        formRef.current?.setFieldValue(
+          'garnishes',
+          props.cocktailRecipe?.garnishes.map((garnish) => {
+            return {
+              ...garnish,
+              garnishId: garnish.garnishId ?? '',
+              garnish: garnishes.find((g) => g.id == garnish.garnishId) ?? undefined,
+            };
+          }),
+        );
+      }
+    } else {
       formRef.current?.setFieldValue(
         'garnishes',
-        props.cocktailRecipe?.garnishes.map((garnish) => {
+        formRef.current?.values.garnishes.map((garnish: any) => {
           return {
             ...garnish,
-            garnishId: garnish.garnishId ?? '',
             garnish: garnishes.find((g) => g.id == garnish.garnishId) ?? undefined,
           };
         }),
@@ -239,13 +244,31 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
   }, [garnishes, props.cocktailRecipe, props.cocktailRecipe?.garnishes]);
 
   useEffect(() => {
-    if (props.cocktailRecipe?.steps.some((step) => step.ingredients.map((ingredient) => ingredient).length > 0) && ingredients.length > 0) {
+    // Otherwise not saved changes will be overwritten
+    if (formRef.current?.values.steps == undefined) {
+      if (props.cocktailRecipe?.steps.some((step) => step.ingredients.map((ingredient) => ingredient).length > 0) && ingredients.length > 0) {
+        formRef.current?.setFieldValue(
+          'steps',
+          props.cocktailRecipe?.steps.map((step) => {
+            return {
+              ...step,
+              ingredients: step.ingredients.map((ingredient) => {
+                return {
+                  ...ingredient,
+                  ingredient: ingredients.find((i) => i.id == ingredient.ingredientId) ?? undefined,
+                };
+              }),
+            };
+          }),
+        );
+      }
+    } else {
       formRef.current?.setFieldValue(
         'steps',
-        props.cocktailRecipe?.steps.map((step) => {
+        formRef.current?.values.steps.map((step: any) => {
           return {
             ...step,
-            ingredients: step.ingredients.map((ingredient) => {
+            ingredients: step.ingredients.map((ingredient: any) => {
               return {
                 ...ingredient,
                 ingredient: ingredients.find((i) => i.id == ingredient.ingredientId) ?? undefined,
@@ -256,6 +279,13 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
       );
     }
   }, [ingredients, props.cocktailRecipe?.steps]);
+
+  useEffect(() => {
+    fetchActions();
+    fetchGarnishes();
+    fetchIngredients();
+    fetchGlasses();
+  }, [fetchActions, fetchGarnishes, fetchGlasses, fetchIngredients]);
 
   const initSteps: CocktailRecipeStepFull[] = props.cocktailRecipe?.steps ?? [];
 
@@ -564,8 +594,9 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                             <FormModal<Glass>
                               form={
                                 <GlassForm
-                                  onSaved={async () => {
+                                  onSaved={async (id) => {
                                     modalContext.closeModal();
+                                    await setFieldValue('glassId', id);
                                     await fetchGlasses();
                                   }}
                                 />
@@ -946,8 +977,9 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                               <FormModal<Ingredient>
                                                 form={
                                                   <IngredientForm
-                                                    onSaved={async () => {
+                                                    onSaved={async (id) => {
                                                       modalContext.closeModal();
+                                                      await setFieldValue(`steps.${indexStep}.ingredients.${indexIngredient}.ingredientId`, id);
                                                       await fetchIngredients();
                                                     }}
                                                   />
@@ -1134,8 +1166,9 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                       <FormModal<Garnish>
                                         form={
                                           <GarnishForm
-                                            onSaved={async () => {
+                                            onSaved={async (id) => {
                                               modalContext.closeModal();
+                                              await setFieldValue(`garnishes.${indexGarnish}.garnishId`, id);
                                               await fetchGarnishes();
                                             }}
                                           />

--- a/components/garnishes/GarnishForm.tsx
+++ b/components/garnishes/GarnishForm.tsx
@@ -16,7 +16,7 @@ interface GarnishFormProps {
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   formRef?: React.RefObject<FormikProps<any>>;
 
-  onSaved?: () => void;
+  onSaved?: (id: string) => void;
 }
 
 export function GarnishForm(props: GarnishFormProps) {
@@ -60,7 +60,7 @@ export function GarnishForm(props: GarnishFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved != undefined) {
-                props.onSaved();
+                props.onSaved((await response.json()).data.id);
               } else {
                 router.push(`/workspaces/${workspaceId}/manage/garnishes`).then(() => alertService.success('Garnitur erfolgreich erstellt'));
               }
@@ -77,7 +77,7 @@ export function GarnishForm(props: GarnishFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved != undefined) {
-                props.onSaved();
+                props.onSaved(props.garnish.id);
               } else {
                 router.push(`/workspaces/${workspaceId}/manage/garnishes`).then(() => alertService.success('Garnitur erfolgreich gespeichert'));
               }

--- a/components/glasses/GlassForm.tsx
+++ b/components/glasses/GlassForm.tsx
@@ -15,7 +15,7 @@ interface GlassFormProps {
   glass?: GlassWithImage;
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   formRef?: React.RefObject<FormikProps<any>>;
-  onSaved?: () => void;
+  onSaved?: (id: string) => void;
 }
 
 export function GlassForm(props: GlassFormProps) {
@@ -60,7 +60,7 @@ export function GlassForm(props: GlassFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved) {
-                props.onSaved();
+                props.onSaved((await response.json()).data.id);
               } else {
                 router.push(`/workspaces/${workspaceId}/manage/glasses`).then(() => alertService.success('Glas erfolgreich erstellt'));
               }
@@ -77,7 +77,7 @@ export function GlassForm(props: GlassFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved) {
-                props.onSaved();
+                props.onSaved(props.glass.id);
               } else {
                 router.push(`/workspaces/${workspaceId}/manage/glasses`).then(() => alertService.success('Glas erfolgreich gespeichert'));
               }

--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -18,7 +18,7 @@ interface IngredientFormProps {
   ingredient?: IngredientWithImage;
   setUnsavedChanges?: (unsavedChanges: boolean) => void;
   formRef?: React.RefObject<FormikProps<any>>;
-  onSaved?: () => void;
+  onSaved?: (id: string) => void;
 }
 
 export function IngredientForm(props: IngredientFormProps) {
@@ -66,7 +66,7 @@ export function IngredientForm(props: IngredientFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved != undefined) {
-                props.onSaved();
+                props.onSaved((await response.json()).data.id);
               } else {
                 router.replace(`/workspaces/${workspaceId}/manage/ingredients`).then(() => alertService.success('Zutat erfolgreich erstellt'));
               }
@@ -83,7 +83,7 @@ export function IngredientForm(props: IngredientFormProps) {
             });
             if (response.status.toString().startsWith('2')) {
               if (props.onSaved != undefined) {
-                props.onSaved();
+                props.onSaved(props.ingredient.id);
               } else {
                 router.replace(`/workspaces/${workspaceId}/manage/ingredients`).then(() => alertService.success('Zutat erfolgreich gespeichert'));
               }

--- a/pages/api/workspaces/[workspaceId]/garnishes/index.tsx
+++ b/pages/api/workspaces/[workspaceId]/garnishes/index.tsx
@@ -53,6 +53,6 @@ export default withHttpMethods({
       });
     }
 
-    return res.json(result);
+    return res.json({ data: result });
   }),
 });


### PR DESCRIPTION
## Closing issues:

- Closes: #132 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

An update of the ingredient list or garnish list was resettig the form arrays. The useEffect watched on the `ingredients` and if there was a change, the form was overwritten with the data given from the props. By changing the whole behavior at the until now not existing synchronisation between ingredientId and ingredient (object) in the form to a synchronisation (with the else clause) this solves the overwriting. This helps also that ingredients, garnishes or glasses which are created by the form, gets automaticly set.  

## Affected sites (please check during review):

- [x] /manage/cocktails/<[id]/create> - Check the cocktail form behavior (creation and update of a cocktail) on how it acts when an ingredient, glass or garnish was created or selected 

## Further comments

-

