### PR TITLE
fix: Cocktail forms calculation was not shown properly, changed volume validation at ingredients form

### DIFF
--- a/components/cocktails/CocktailRecipeForm.tsx
+++ b/components/cocktails/CocktailRecipeForm.tsx
@@ -713,31 +713,27 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                       <div className={'divider-sm col-span-2'}>Zutaten</div>
                       {(values.steps as CocktailRecipeStepFull[]).filter((step) => step.ingredients.some((ingredient) => ingredient.ingredient != undefined))
                         .length > 0 ? (
-                        (values.garnishes as CocktailRecipeGarnishFull[]).length > 0 ? (
-                          <>
-                            {(values.steps as CocktailRecipeStepFull[])
-                              .map((step) => step.ingredients.filter((ingredient) => ingredient.ingredient != undefined))
-                              .flat()
-                              ?.map((ingredient, indexIngredient) => (
-                                <>
-                                  <div key={`price-calculation-step-${indexIngredient}-name`}>
-                                    {ingredient.ingredient?.shortName ?? ingredient.ingredient?.name}
+                        <>
+                          {(values.steps as CocktailRecipeStepFull[])
+                            .map((step) => step.ingredients.filter((ingredient) => ingredient.ingredient != undefined))
+                            .flat()
+                            ?.map((ingredient, indexIngredient) => (
+                              <>
+                                <div key={`price-calculation-step-${indexIngredient}-name`}>
+                                  {ingredient.ingredient?.shortName ?? ingredient.ingredient?.name}
+                                </div>
+                                <div key={`price-calculation-step-${indexIngredient}-price`} className={'grid grid-cols-2'}>
+                                  <div>
+                                    {ingredient.amount} x {((ingredient.ingredient?.price ?? 0) / (ingredient.ingredient?.volume ?? 1)).toFixed(2)}
                                   </div>
-                                  <div key={`price-calculation-step-${indexIngredient}-price`} className={'grid grid-cols-2'}>
-                                    <div>
-                                      {ingredient.amount} x {((ingredient.ingredient?.price ?? 0) / (ingredient.ingredient?.volume ?? 1)).toFixed(2)}
-                                    </div>
-                                    <div className={'text-end'}>
-                                      {indexIngredient > 0 ? '+ ' : ''}
-                                      {(((ingredient.ingredient?.price ?? 0) / (ingredient.ingredient?.volume ?? 1)) * (ingredient.amount ?? 0)).toFixed(2)}€
-                                    </div>
+                                  <div className={'text-end'}>
+                                    {indexIngredient > 0 ? '+ ' : ''}
+                                    {(((ingredient.ingredient?.price ?? 0) / (ingredient.ingredient?.volume ?? 1)) * (ingredient.amount ?? 0)).toFixed(2)}€
                                   </div>
-                                </>
-                              ))}
-                          </>
-                        ) : (
-                          <></>
-                        )
+                                </div>
+                              </>
+                            ))}
+                        </>
                       ) : (
                         <div className={'col-span-2 text-center font-thin italic'}>Keine Zutaten</div>
                       )}

--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -125,6 +125,9 @@ export function IngredientForm(props: IngredientFormProps) {
         if (values.volume.toString() == '' || isNaN(values.volume)) {
           errors.volume = 'Required';
         }
+        if (values.volume <= 0) {
+          errors.volume = 'Muss größer 0 sein';
+        }
         if (!values.unit) {
           errors.unit = 'Required';
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8656,11 +8656,11 @@ __metadata:
 
 "typescript@patch:typescript@5.3.3#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Closing issues:

- Closes: #187 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

- There was a wrong condition in the financial card, which results that the ingredients were not shown
- I had some ingredients with volume = 0 -> so a division by 0 throws a NaN error -> fixed this for future edits by adding a check at the form (not 100 % save, but a fast workaround)

## Affected sites (please check during review):

- [ ] CocktailForms Financial Pane
- [x] IngredientForm volume validation (only > 0 is now allowed)

