### PR TITLE
fix: Glass form was not accessable if the glass had no image

### DIFF
--- a/components/glasses/GlassForm.tsx
+++ b/components/glasses/GlassForm.tsx
@@ -40,7 +40,7 @@ export function GlassForm(props: GlassFormProps) {
       initialValues={{
         name: props.glass?.name ?? '',
         deposit: props.glass?.deposit ?? 0,
-        image: props.glass?.GlassImage[0].image ?? undefined,
+        image: props.glass?.GlassImage?.[0]?.image ?? undefined,
         volume: props.glass?.volume ?? 0,
       }}
       onSubmit={async (values) => {


### PR DESCRIPTION
## Closing issues:

- Closes: #186 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

If an glass had no image, the field "GlassImages" is undefined. So the access on that undefined throwes an exception. 

## Affected sites (please check during review):

- [x] Glass form editing a glass without an image

