### PR TITLE
fix: Image selector set the wrong when field when creating ingredient/glass/garnish (with image) from the cocktail edit view

### DIFF
--- a/components/UploadDropZone.tsx
+++ b/components/UploadDropZone.tsx
@@ -7,6 +7,8 @@ interface UploadDropZoneProps {
 }
 
 export function UploadDropZone(props: UploadDropZoneProps) {
+  const identifier = Math.floor(Math.random() * 1000000);
+
   return (
     <div className="flex h-full w-full items-center justify-center">
       {isMobile ? (
@@ -61,7 +63,7 @@ export function UploadDropZone(props: UploadDropZoneProps) {
         </>
       ) : (
         <label
-          htmlFor="dropzone-file"
+          htmlFor={'dropzone-file-' + identifier}
           className="flex h-full w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-base-300 bg-base-200 hover:border-base-300 hover:bg-base-100 dark:bg-base-200 dark:hover:bg-base-100"
         >
           <div className="font-bo text-2xl">Bild wählen</div>
@@ -95,9 +97,9 @@ export function UploadDropZone(props: UploadDropZoneProps) {
             )}
           </div>
           <input
-            id="dropzone-file"
+            id={'dropzone-file-' + identifier}
             type="file"
-            name="file"
+            name={`file-${identifier}`}
             className="hidden"
             capture="environment"
             accept={'image/*'}

--- a/components/layout/AlertBoundary/index.tsx
+++ b/components/layout/AlertBoundary/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertsContainer } from './AlertsContainer';
+import { FaExclamationTriangle } from 'react-icons/fa';
 
 interface AlertBoundaryProps {
   children: React.ReactNode;
@@ -8,6 +9,19 @@ interface AlertBoundaryProps {
 export function AlertBoundary(props: AlertBoundaryProps) {
   return (
     <div>
+      <>
+        {process.env.NODE_ENV == 'development' ? (
+          <>
+            <div className={'fixed top-0 z-50  flex h-10 w-full flex-row items-center justify-center gap-2 overflow-hidden bg-warning p-2 text-white'}>
+              <FaExclamationTriangle />
+              Achtung sie befinden sich in der Entwicklungs-Umgebung
+            </div>
+            <div className={'h-10'}></div>
+          </>
+        ) : (
+          <></>
+        )}
+      </>
       <div className="fixed right-2 top-2 z-50 ml-2 flex flex-col items-center justify-center overflow-hidden md:right-10 md:top-10 print:hidden">
         <AlertsContainer />
       </div>


### PR DESCRIPTION
## Closing issues:

- Closes: #192 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

By adding a unique identifier to the multiple used component "UploadDropZone" the image gets set corretly

## Affected sites (please check during review):

- [x] CocktailForm

