### PR TITLE
fix: Fixed incorrect bar orders at statistics and coresponding ui

### DIFF
--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -76,7 +76,7 @@ export default function CocktailRecipeCardItem(props: CocktailRecipeOverviewItem
               <></>
             )}
             {props.showStatisticActions ? (
-              <button className={'btn btn-outline btn-primary w-full'} onClick={addCocktailToStatistic} disabled={submittingStatistic}>
+              <button className={'btn btn-outline btn-primary mt-1 w-full'} onClick={addCocktailToStatistic} disabled={submittingStatistic}>
                 <FaPlus />
                 Gemacht
                 {submittingStatistic ? <span className={'loading loading-spinner'}></span> : <></>}

--- a/components/modals/SearchModal.tsx
+++ b/components/modals/SearchModal.tsx
@@ -192,7 +192,7 @@ export function SearchModal(props: SearchModalProps) {
 
                     {props.showStatisticActions ? (
                       <button
-                        className={'btn btn-outline btn-primary w-full'}
+                        className={'btn btn-outline btn-primary mt-2 w-full'}
                         onClick={() => addCocktailToStatistic(cocktail.id)}
                         disabled={submittingStatistic}
                       >

--- a/migrations/20240405142613_fixed_statistics_on_deletion/migration.sql
+++ b/migrations/20240405142613_fixed_statistics_on_deletion/migration.sql
@@ -1,0 +1,19 @@
+-- DropForeignKey
+ALTER TABLE "CocktailStatisticItem"
+    DROP CONSTRAINT "CocktailStatisticItem_cocktailCardId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CocktailStatisticItem"
+    DROP CONSTRAINT "CocktailStatisticItem_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "CocktailStatisticItem"
+    ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "CocktailStatisticItem"
+    ADD CONSTRAINT "CocktailStatisticItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CocktailStatisticItem"
+    ADD CONSTRAINT "CocktailStatisticItem_cocktailCardId_fkey" FOREIGN KEY ("cocktailCardId") REFERENCES "CocktailCard" ("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/schema.prisma
+++ b/schema.prisma
@@ -343,13 +343,13 @@ model CocktailStatisticItem {
   id             String         @id @default(cuid())
   cocktailId     String
   cocktail       CocktailRecipe @relation(fields: [cocktailId], references: [id], onDelete: Cascade)
-  userId         String
-  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId         String?
+  user           User?          @relation(fields: [userId], references: [id], onDelete: SetNull)
   workspaceId    String
   workspace      Workspace      @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   date           DateTime
   cocktailCardId String?
-  cocktailCard   CocktailCard?  @relation(fields: [cocktailCardId], references: [id], onDelete: Cascade)
+  cocktailCard   CocktailCard?  @relation(fields: [cocktailCardId], references: [id], onDelete: SetNull)
   actionSource   String?
 }
 


### PR DESCRIPTION
## Closing issues:

- Closes: #215 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Fixed the coresponding issue, by solving the chart bar order to the correct way and some ui issues, see below.

## Affected sites (please check during review):

- [x] [workspaceId]/mange/statistics/index.tsx - Fixed the ordering of the groups, added query params to define dates and fixed date field order on mobile view
- [x] [workspaceId]/index.tsx - Fixed the padding of the "Gemacht" button

