### PR TITLE
fix: Image size on bartender´s view

### DIFF
--- a/components/cocktails/CompactCocktailRecipeInstruction.tsx
+++ b/components/cocktails/CompactCocktailRecipeInstruction.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import DefaultGlassIcon from '../DefaultGlassIcon';
 import { UserContext } from '../../lib/context/UserContextProvider';
 import Image from 'next/image';
+import { ModalContext } from '../../lib/context/ModalContextProvider';
 
 interface CompactCocktailRecipeInstructionProps {
   cocktailRecipe: CocktailRecipeFull;
@@ -14,6 +15,7 @@ interface CompactCocktailRecipeInstructionProps {
 
 export function CompactCocktailRecipeInstruction(props: CompactCocktailRecipeInstructionProps) {
   const userContext = useContext(UserContext);
+  const modalContext = useContext(ModalContext);
 
   return (
     <div className={'grid grid-cols-4 gap-1'}>
@@ -71,8 +73,21 @@ export function CompactCocktailRecipeInstruction(props: CompactCocktailRecipeIns
         ) : (
           <div className={'row-span-3 h-full self-center justify-self-center pt-2'}>
             <Image
+              onClick={() =>
+                modalContext.openModal(
+                  <div className={'flex h-[60vh] w-full items-center justify-center'}>
+                    <Image
+                      src={props.image ?? `/api/workspaces/${props.cocktailRecipe.workspaceId}/cocktails/${props.cocktailRecipe.id}/image`}
+                      className={'h-full w-full rounded-xl object-contain'}
+                      alt={'Cocktail-Bild'}
+                      width={400}
+                      height={400}
+                    />
+                  </div>,
+                )
+              }
               src={props.image ?? `/api/workspaces/${props.cocktailRecipe.workspaceId}/cocktails/${props.cocktailRecipe.id}/image`}
-              className={'h-full w-fit rounded-xl object-cover'}
+              className={'h-full w-fit cursor-pointer rounded-xl object-cover'}
               alt={''}
               width={300}
               height={300}

--- a/components/modals/GlobalModal.tsx
+++ b/components/modals/GlobalModal.tsx
@@ -27,7 +27,7 @@ export function GlobalModal(props: GlobalModalProps) {
       {props.children}
       <input type="checkbox" id="globalModal" className="modal-toggle" />
       <label htmlFor="globalModal" className="modal cursor-pointer">
-        <label className="modal-box relative w-full p-1.5 md:max-w-2xl md:p-4" htmlFor="">
+        <label className={`modal-box relative w-full p-1.5 md:max-w-2xl md:p-4`} htmlFor="">
           <label htmlFor="globalModal" className="btn btn-circle btn-outline btn-sm absolute right-2 top-2">
             <FaTimes />
           </label>


### PR DESCRIPTION
## Closing issues:

- Closes: #238 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Images can be shown as modal from the bar tenders view

## Affected sites (please check during review):

- [ ] [workspaceId]/index - Have a click on the cocktail image

