### PR TITLE
fix: Ordered workspaces by last opened

### DIFF
--- a/migrations/20240419083417_added_last_workspace_opened/migration.sql
+++ b/migrations/20240419083417_added_last_workspace_opened/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "WorkspaceUser"
+    ADD COLUMN "lastOpened" TIMESTAMP(3);

--- a/pages/api/workspaces/[workspaceId]/index.ts
+++ b/pages/api/workspaces/[workspaceId]/index.ts
@@ -8,6 +8,19 @@ import WorkspaceUpdateInput = Prisma.WorkspaceUpdateInput;
 export default withHttpMethods({
   [HTTPMethod.GET]: withWorkspacePermission([Role.USER], async (req, res, user, workspace) => {
     const settings = await prisma.workspaceSetting.findMany({ where: { workspaceId: workspace.id } });
+
+    await prisma.workspaceUser.update({
+      where: {
+        workspaceId_userId: {
+          workspaceId: workspace.id,
+          userId: user.id,
+        },
+      },
+      data: {
+        lastOpened: new Date(),
+      },
+    });
+
     return res.json({ data: { ...workspace, WorkspaceSetting: settings } });
   }),
   [HTTPMethod.DELETE]: withWorkspacePermission([Role.ADMIN], async (req, res, user, workspace) => {

--- a/pages/api/workspaces/index.ts
+++ b/pages/api/workspaces/index.ts
@@ -216,8 +216,17 @@ export default withHttpMethods({
           },
         },
       },
+      include: {
+        users: true,
+      },
     });
 
-    return res.json({ data: result });
+    const sortedResult = result.sort(
+      (a, b) =>
+        (b.users?.find((u) => u.userId == user.id)?.lastOpened || new Date(1970, 1, 1)).getTime() -
+        (a.users?.find((u) => u.userId == user.id)?.lastOpened || new Date(1970, 1, 1)).getTime(),
+    );
+
+    return res.json({ data: sortedResult });
   }),
 });

--- a/schema.prisma
+++ b/schema.prisma
@@ -128,6 +128,8 @@ model WorkspaceUser {
   userId      String // relation scalar field (used in the `@relation` attribute above)
   role        Role
 
+  lastOpened DateTime?
+
   @@id([workspaceId, userId])
 }
 


### PR DESCRIPTION
## Closing issues:

- Closes: #245 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [x] No build errors (`yarn build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

There was no ordering when you have multiple workspaces. Now its sorted by the last visit.

## Affected sites (please check during review):

- [x] index - Update last seen when GET /workspace/id to sort it by the lastOpened date at the index site