### PR TITLE
fix: Capital F not working at SearchModal

### DIFF
--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -35,7 +35,9 @@ export default function OverviewPage() {
   useEffect(() => {
     const handleSearchShortCut = (event: any) => {
       if (event.shiftKey && event.key === 'F') {
-        modalContext.openModal(<SearchModal showStatisticActions={showStatisticActions} />);
+        if (!(document.querySelector('#globalModal') as any)?.checked) {
+          modalContext.openModal(<SearchModal showStatisticActions={showStatisticActions} />);
+        }
       }
     };
     window.addEventListener('keypress', handleSearchShortCut);


### PR DESCRIPTION
## Closing issues:

- Closes: #267 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I´e created all necessary migrations?
- [ ] The format is correct (`yarn format:check`, if invalid `yarn format:fix`)
- [ ] No build errors (`yarn build`)
- [ ] I´ve tested the implemented function by my own
- [ ] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Added condition, if the search modal is already opened, it won´t be opened again. Resulting, that you´re able to type capital "F".

## Affected sites (please check during review):

- [x] [workspaceId]/index

