### PR TITLE
fix: Wrong unit conversion after conalco import

### DIFF
--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -502,6 +502,7 @@ export function IngredientForm(props: IngredientFormProps) {
                           if (data.volume != 0) {
                             setFieldValue('volume', data.volume);
                           }
+                          setFieldValue('selectedUnit', allUnits.find((unit) => unit.name == 'CL')?.id ?? '');
                         });
                       } else {
                         alertService.warn('Es konnten keine Daten über die URL geladen werden.');

--- a/pages/api/scraper/ingredient.tsx
+++ b/pages/api/scraper/ingredient.tsx
@@ -30,7 +30,7 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse) 
       const image = imageResponse != undefined ? 'data:image/jpg;base64,' + Buffer.from(await imageResponse.arrayBuffer()).toString('base64') : undefined;
       const name = soup.find('h1', 'product--title')?.text?.replace('\n', '')?.trim() ?? '';
       const price = soup.find('meta', { itemprop: 'price' })?.attrs?.content ?? 0;
-      const volume = (soup.find('div', ['product--price', 'price--unit'])?.contents?.[1]?.['_text']?.split(' ')?.[0] ?? 0) * 1000;
+      const volume = (soup.find('div', ['product--price', 'price--unit'])?.contents?.[1]?.['_text']?.split(' ')?.[0] ?? 0) * 100;
 
       const result: ResponseBody = {
         name: name,


### PR DESCRIPTION
## Closing issues:

- Closes: #<issue id>

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

I changed the unit conversion from "L" -> "ml" to "L" -> "cl" and added a "cl" selection after the conalco import 

## Affected sites (please check during review):

- [ ] [workspaceId]/manage/ingredient/<id|new> - When fetching ingredients from conalco.de


