### PR TITLE
feat: Added cocktail description to cocktail card at search modal and search page

### DIFF
--- a/components/AvatarImage.tsx
+++ b/components/AvatarImage.tsx
@@ -26,7 +26,7 @@ export default function AvatarImage(props: AvatarImageProps) {
           height={300}
         />
       </div>
-      <div className={'z-100 absolute h-full w-full'}>
+      <div className={'z-100 absolute flex h-full w-full items-center justify-center'}>
         <Image
           className={'h-full w-min object-contain'}
           src={props.src}

--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -14,6 +14,7 @@ interface CocktailRecipeOverviewItemProps {
   showPrice?: boolean;
   showInfo?: boolean;
   showTags?: boolean;
+  showDescription?: boolean;
   showStatisticActions?: boolean;
   image?: string;
 }
@@ -38,6 +39,15 @@ export default function CocktailRecipeCardItem(props: CocktailRecipeOverviewItem
           />
           <div className={'h-full'}></div>
           <div className={'bottom-0'}>
+            {props.showDescription && props.cocktailRecipe.description ? (
+              <>
+                <div className={'col-span-4 mb-2 border-b border-base-100'}></div>
+                <div className={'pb-2 font-bold'}>Beschreibung</div>
+                <div className={'whitespace-pre-line text-pretty break-normal text-justify'}>{props.cocktailRecipe.description}</div>
+              </>
+            ) : (
+              <></>
+            )}
             {props.showTags ? (
               props.cocktailRecipe.tags.map((tag) => (
                 <span key={`cocktail-overview-item-${props.cocktailRecipe.id}-tag-${tag}`} className={'badge badge-primary badge-outline mr-1'}>

--- a/components/cocktails/CompactCocktailRecipeInstruction.tsx
+++ b/components/cocktails/CompactCocktailRecipeInstruction.tsx
@@ -100,7 +100,7 @@ export function CompactCocktailRecipeInstruction(props: CompactCocktailRecipeIns
       {props.cocktailRecipe.garnishes.length == 0 ? (
         <></>
       ) : (
-        <div className={`border-b border-base-100 ${props.showImage == true ? 'col-span-3' : 'col-span-4'}`}></div>
+        <div className={`border-b border-base-100 ${props.showImage == true && props.image ? 'col-span-3' : 'col-span-4'}`}></div>
       )}
       <div className={`${props.showImage == true ? 'col-span-3' : 'col-span-4'}`}>
         {props.cocktailRecipe.garnishes.length == 0 ? <></> : <div className={'font-bold'}>Deko</div>}

--- a/components/modals/SearchModal.tsx
+++ b/components/modals/SearchModal.tsx
@@ -1,15 +1,14 @@
 import { BsSearch } from 'react-icons/bs';
-import { CompactCocktailRecipeInstruction } from '../cocktails/CompactCocktailRecipeInstruction';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { CocktailRecipeFull } from '../../models/CocktailRecipeFull';
 import { Loading } from '../Loading';
 import { ModalContext } from '../../lib/context/ModalContextProvider';
-import { ShowCocktailInfoButton } from '../cocktails/ShowCocktailInfoButton';
 import { useRouter } from 'next/router';
 import { alertService } from '../../lib/alertService';
 import { FaPlus } from 'react-icons/fa';
 import { MdPlaylistAdd } from 'react-icons/md';
 import { addCocktailToQueue, addCocktailToStatistic } from '../../lib/network/cocktailTracking';
+import CocktailRecipeCardItem from '../cocktails/CocktailRecipeCardItem';
 
 interface SearchModalProps {
   onCocktailSelectedObject?: (cocktail: CocktailRecipeFull) => void;
@@ -135,12 +134,15 @@ export function SearchModal(props: SearchModalProps) {
                 </div>
                 {showRecipe && (
                   <div className="collapse-content pl-2 pr-2 md:pl-3">
-                    <div className={'card'}>
-                      <div className={'card-body'}>
-                        <ShowCocktailInfoButton showInfo={true} cocktailRecipe={cocktail} />
-                        <CompactCocktailRecipeInstruction showPrice={true} cocktailRecipe={cocktail} showImage={true} />
-                      </div>
-                    </div>
+                    <CocktailRecipeCardItem
+                      cocktailRecipe={cocktail}
+                      showImage={true}
+                      showTags={true}
+                      showDescription={true}
+                      showStatisticActions={false}
+                      showPrice={true}
+                      showInfo={true}
+                    />
 
                     {props.onCocktailSelectedObject != undefined ? (
                       <div className={'card-actions flex flex-row justify-end pt-2'}>

--- a/pages/workspaces/[workspaceId]/search.tsx
+++ b/pages/workspaces/[workspaceId]/search.tsx
@@ -26,6 +26,7 @@ export default function SearchPage(props: SearchPageProps) {
             showImage={props.showImage}
             showInfo={true}
             showPrice={true}
+            showDescription={true}
             showTags={props.showTags}
             showStatisticActions={props.showStatisticActions}
           />


### PR DESCRIPTION
## Closing issues:

- Closes: #338 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

When using the search page, the cocktail description gets now displayed. Same as in the search modal.

## Affected sites (please check during review):

- [x] [workspaceId]/index.txt - Search Modal, description and tags now shown if they exists
- [x] [workspaceId]/search.txt - Cocktail card display description always (if exists)

