### PR TITLE
fix: Fixed closing modal bug in chrome/-ium and safari and added stackable modals

### DIFF
--- a/components/cocktails/CocktailRecipeForm.tsx
+++ b/components/cocktails/CocktailRecipeForm.tsx
@@ -220,7 +220,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
     tags: props.cocktailRecipe?.tags ?? [],
     glassWithIce: props.cocktailRecipe?.glassWithIce ?? IceType.Without,
     image: props.cocktailRecipe?.CocktailRecipeImage[0]?.image ?? undefined,
-    glassId: props.cocktailRecipe?.glassId ?? null,
+    glassId: props.cocktailRecipe?.glassId ?? undefined,
     glass: glasses.find((g) => g.id == props.cocktailRecipe?.glassId) ?? null,
     garnishes: props.cocktailRecipe?.garnishes ?? [],
     steps: initSteps,
@@ -402,7 +402,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                 <div className={'divider'}></div>
                 <div className={'grid grid-cols-2 gap-4'}>
                   <div className={'col-span-2'}>
-                    <label className={'label'}>
+                    <label className={'label'} htmlFor={'name'}>
                       <span className={'label-text'}>Name</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.name && touched.name && errors.name}</> *
@@ -411,6 +411,8 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     <input
                       type="text"
                       name="name"
+                      autoComplete={'off'}
+                      id={'name'}
                       className={`input input-bordered w-full ${errors.name && touched.name && 'input-error'}`}
                       onChange={handleChange}
                       onBlur={handleBlur}
@@ -418,13 +420,14 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     />
                   </div>
                   <div className={'col-span-2'}>
-                    <label className={'label'}>
+                    <label className={'label'} htmlFor={'description'}>
                       <span className={'label-text'}>Beschreibung</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.description && touched.description && errors.description}</>
                       </span>
                     </label>
                     <textarea
+                      id={'description'}
                       name="description"
                       className={`textarea textarea-bordered w-full ${errors.description && touched.description && 'textarea-error'}`}
                       onChange={handleChange}
@@ -433,7 +436,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     />
                   </div>
                   <div className={'col-span-2 md:col-span-1'}>
-                    <label className={'label'}>
+                    <label className={'label'} htmlFor={'price'}>
                       <span className={'label-text'}>Preis</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.price && touched.price && errors.price}</>
@@ -441,6 +444,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     </label>
                     <div className={'join w-full'}>
                       <input
+                        id={'price'}
                         type="number"
                         className={`input join-item input-bordered w-full ${errors.price && touched.price && 'input-error'}`}
                         name="price"
@@ -454,27 +458,29 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     </div>
                   </div>
                   <div className={'col-span-2 md:col-span-1'}>
-                    <label className={'label'}>
+                    <div className={'label'}>
                       <span className={'label-text'}>Tags</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.tags && touched.tags && errors.tags}</>
                       </span>
-                    </label>
-                    <TagsInput
-                      value={values.tags}
-                      onChange={(tags) =>
-                        setFieldValue(
-                          'tags',
-                          updateTags(tags, (text) => setFieldError('tags', text ?? 'Tag fehlerhaft')),
-                        )
-                      }
-                      name="tags"
-                      beforeAddValidate={(tag, _) => validateTag(tag, (text) => setFieldError('tags', text ?? 'Tag fehlerhaft'))}
-                      onBlur={handleBlur}
-                    />
+                    </div>
+                    <div id={'tags'}>
+                      <TagsInput
+                        value={values.tags}
+                        onChange={(tags) =>
+                          setFieldValue(
+                            'tags',
+                            updateTags(tags, (text) => setFieldError('tags', text ?? 'Tag fehlerhaft')),
+                          )
+                        }
+                        name="tags"
+                        beforeAddValidate={(tag, _) => validateTag(tag, (text) => setFieldError('tags', text ?? 'Tag fehlerhaft'))}
+                        onBlur={handleBlur}
+                      />
+                    </div>
                   </div>
                   <div>
-                    <label className={'label'}>
+                    <label className={'label'} htmlFor={'glassId'}>
                       <span className={'label-text'}>Glas</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.glassId && touched.glassId && errors.glassId}</> *
@@ -482,6 +488,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     </label>
                     <div className={'join w-full'}>
                       <select
+                        id={'glassId'}
                         name="glassId"
                         className={`join-item select select-bordered w-full ${errors.glassId && touched.glassId && 'select-error'}`}
                         onChange={(event) => {
@@ -534,13 +541,14 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     </div>
                   </div>
                   <div>
-                    <label className={'label'}>
+                    <label className={'label'} htmlFor={'iceId'}>
                       <span className={'label-text'}>Eis</span>
                       <span className={'label-text-alt text-error'}>
                         <>{errors.glassWithIce && touched.glassWithIce && errors.glassWithIce}</>
                       </span>
                     </label>
                     <select
+                      id={'iceId'}
                       name="glassWithIce"
                       className={`select select-bordered w-full ${errors.glassWithIce && touched.glassWithIce && 'select-error'}`}
                       onChange={handleChange}
@@ -737,7 +745,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     <div className={'col-span-2 space-y-2'}>
                       {(values.steps as CocktailRecipeStepFull[]).map((step, indexStep) => (
                         <div
-                          key={`form-recipe-step-${step.id}-${indexStep}`}
+                          key={`form-recipe-step-${indexStep}`}
                           className={'flex w-full flex-col justify-between space-y-2 rounded-xl border border-neutral p-4'}
                         >
                           <div className={'grid grid-cols-2 gap-2 md:grid-cols-3 md:gap-4'}>
@@ -760,11 +768,11 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                   <option disabled={true}>Lade...</option>
                                 ) : (
                                   Object.entries(_.groupBy(actions, 'actionGroup')).map(([group, groupActions]) => (
-                                    <optgroup key={`form-recipe-step-${step.id}-action-group-${group}`} label={userContext.getTranslation(group, 'de')}>
+                                    <optgroup key={`form-recipe-step-${indexStep}-action-group-${group}`} label={userContext.getTranslation(group, 'de')}>
                                       {groupActions
                                         .sort((a, b) => a.name.localeCompare(b.name))
-                                        .map((action) => (
-                                          <option key={`form-recipe-step-${step.id}-action-${action.id}`} value={action.id}>
+                                        .map((action, indexAction) => (
+                                          <option key={`form-recipe-step-${indexStep}-action-${indexAction}`} value={action.id}>
                                             {userContext.getTranslation(action.name, 'de')}
                                           </option>
                                         ))}
@@ -832,7 +840,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                 {step.ingredients
                                   .sort((a, b) => a.ingredientNumber - b.ingredientNumber)
                                   .map((ingredient, indexIngredient) => (
-                                    <div key={`form-recipe-step-${step.id}-ingredient-${ingredient.id}`} className={'flex flex-row gap-2 pt-2'}>
+                                    <div key={`form-recipe-step-${indexStep}-ingredient-${indexIngredient}`} className={'flex flex-row gap-2 pt-2'}>
                                       <div className={'join join-vertical w-min items-center justify-center'}>
                                         <button
                                           type={'button'}
@@ -883,6 +891,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                       <div className={'grid w-full grid-cols-2 gap-1 md:grid-cols-3'}>
                                         <div key={`form-recipe-step${step.id}-ingredient-${ingredient.id}`} className={'join col-span-2 flex w-full flex-row'}>
                                           <input
+                                            id={`ingredient-${indexIngredient}-name`}
                                             className={`input join-item input-bordered w-full cursor-pointer ${
                                               ((errors.steps as StepError[])?.[indexStep] as any)?.ingredients?.[indexIngredient]?.ingredientId && 'input-error'
                                             }`}

--- a/components/garnishes/GarnishForm.tsx
+++ b/components/garnishes/GarnishForm.tsx
@@ -105,7 +105,7 @@ export function GarnishForm(props: GarnishFormProps) {
       {({ values, setFieldValue, errors, touched, handleChange, handleBlur, handleSubmit, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={'flex flex-col gap-2 md:gap-4'}>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'name'}>
               <span className={'label-text'}>Name</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -115,7 +115,9 @@ export function GarnishForm(props: GarnishFormProps) {
               </span>
             </label>
             <input
+              id={'name'}
               type={'text'}
+              autoComplete={'off'}
               placeholder={'Name'}
               className={`input input-bordered ${errors.name && touched.name && 'input-error'} w-full`}
               onChange={handleChange}
@@ -126,7 +128,7 @@ export function GarnishForm(props: GarnishFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'description'}>
               <span className={'label-text'}>Zubereitungsbeschreibung</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -135,6 +137,7 @@ export function GarnishForm(props: GarnishFormProps) {
               </span>
             </label>
             <textarea
+              id={'description'}
               className={`textarea textarea-bordered ${errors.description && touched.description && 'textarea-error'} w-full`}
               value={values.description}
               onChange={handleChange}
@@ -144,7 +147,7 @@ export function GarnishForm(props: GarnishFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'price'}>
               <span className={'label-text'}>Preis</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <>{errors.price && touched.price && errors.price}</>
@@ -152,6 +155,7 @@ export function GarnishForm(props: GarnishFormProps) {
             </label>
             <div className={'join'}>
               <input
+                id={'price'}
                 type={'number'}
                 placeholder={'Preis'}
                 className={`input join-item input-bordered ${errors.price && touched.price && 'input-error'} w-full`}
@@ -165,9 +169,9 @@ export function GarnishForm(props: GarnishFormProps) {
           </div>
           <div className={'col-span-2'}>
             {values.image != undefined ? (
-              <label className={'label'}>
+              <div className={'label'}>
                 <span className={'label-text'}>Zutaten Bild</span>
-              </label>
+              </div>
             ) : (
               <></>
             )}

--- a/components/glasses/GlassForm.tsx
+++ b/components/glasses/GlassForm.tsx
@@ -108,7 +108,7 @@ export function GlassForm(props: GlassFormProps) {
       {({ values, setFieldValue, errors, touched, handleChange, handleBlur, handleSubmit, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={'flex flex-col gap-2 md:gap-4'}>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'name'}>
               <span className={'label-text'}>Name</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -118,6 +118,8 @@ export function GlassForm(props: GlassFormProps) {
               </span>
             </label>
             <input
+              id={'name'}
+              autoComplete={'off'}
               type={'text'}
               placeholder={'Name'}
               className={`input input-bordered w-full ${errors.name && touched.name && 'input-error'}`}
@@ -129,7 +131,7 @@ export function GlassForm(props: GlassFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'deposit'}>
               <span className={'label-text'}>Pfand</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -140,6 +142,7 @@ export function GlassForm(props: GlassFormProps) {
             </label>
             <div className={'join'}>
               <input
+                id={'deposit'}
                 type={'number'}
                 placeholder={'Deposit'}
                 className={`input join-item input-bordered w-full ${errors.deposit && touched.deposit && 'input-error'}}`}
@@ -152,11 +155,12 @@ export function GlassForm(props: GlassFormProps) {
             </div>
           </div>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'volume'}>
               <span className={'label-text'}>Volumen</span>
             </label>
             <div className={'join'}>
               <input
+                id={'volume'}
                 type={'number'}
                 placeholder={'38cl'}
                 className={'input join-item input-bordered w-full'}
@@ -170,9 +174,9 @@ export function GlassForm(props: GlassFormProps) {
           </div>
           <div className={'form-control'}>
             {values.image != undefined ? (
-              <label className={'label'}>
+              <div className={'label'}>
                 <span className={'label-text'}>Vorschau Bild</span>
-              </label>
+              </div>
             ) : (
               <></>
             )}

--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -161,7 +161,7 @@ export function IngredientForm(props: IngredientFormProps) {
       {({ values, setFieldValue, errors, setFieldError, touched, handleChange, handleBlur, handleSubmit, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={'flex flex-col gap-2 md:gap-4'}>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'name'}>
               <span className={'label-text'}>Name</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -171,7 +171,9 @@ export function IngredientForm(props: IngredientFormProps) {
               </span>
             </label>
             <input
+              id={'name'}
               type={'text'}
+              autoComplete={'off'}
               className={`input input-bordered ${errors.name && touched.name && 'input-error'}`}
               onChange={handleChange}
               onBlur={handleBlur}
@@ -180,7 +182,7 @@ export function IngredientForm(props: IngredientFormProps) {
             />
           </div>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'shortName'}>
               <span className={'label-text'}>Abkürzung</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -189,6 +191,7 @@ export function IngredientForm(props: IngredientFormProps) {
               </span>
             </label>
             <input
+              id={'shortName'}
               type={'text'}
               className={`input input-bordered ${errors.shortName && touched.shortName && 'input-error'}`}
               onChange={handleChange}
@@ -199,7 +202,7 @@ export function IngredientForm(props: IngredientFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'description'}>
               <span className={'label-text'}>Allg. Beschreibung</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -208,6 +211,7 @@ export function IngredientForm(props: IngredientFormProps) {
               </span>
             </label>
             <textarea
+              id={'description'}
               className={`textarea textarea-bordered ${errors.description && touched.description && 'textarea-error'} w-full`}
               value={values.description}
               onChange={handleChange}
@@ -217,7 +221,7 @@ export function IngredientForm(props: IngredientFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'notes'}>
               <span className={'label-text'}>Notizen</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -226,6 +230,7 @@ export function IngredientForm(props: IngredientFormProps) {
               </span>
             </label>
             <textarea
+              id={'notes'}
               className={`textarea textarea-bordered ${errors.notes && touched.notes && 'textarea-error'} w-full`}
               value={values.notes}
               onChange={handleChange}
@@ -235,7 +240,7 @@ export function IngredientForm(props: IngredientFormProps) {
           </div>
 
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'price'}>
               <span className={'label-text'}>Preis</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -245,6 +250,7 @@ export function IngredientForm(props: IngredientFormProps) {
             </label>
             <div className={'join'}>
               <input
+                id={'price'}
                 type={'number'}
                 className={`input join-item input-bordered w-full ${errors.price && touched.price && 'input-error'}`}
                 value={values.price}
@@ -282,15 +288,15 @@ export function IngredientForm(props: IngredientFormProps) {
                             {userContext.getTranslation(allUnits.find((availableUnit) => availableUnit.id == unit.unitId)?.name ?? 'N/A', 'de')}
                           </td>
                           <td className={'flex flex-row items-center justify-center'}>
-                            <button
+                            <div
                               className={'btn btn-square btn-error btn-sm'}
-                              type={'button'}
+                              // type={'button'}
                               onClick={() => {
                                 removeUnit(index);
                               }}
                             >
                               <FaTrashAlt />
-                            </button>
+                            </div>
                           </td>
                         </tr>
                       ))
@@ -298,7 +304,7 @@ export function IngredientForm(props: IngredientFormProps) {
                   </tbody>
                 </table>
                 <div className={'form-control'}>
-                  <label className={'label'}>
+                  <label className={'label'} htmlFor={'anotherVolume'}>
                     <span className={'label-text'}>Weitere Menge hinzufügen</span>
                     <span className={'label-text-alt space-x-2 text-error'}>
                       <span>
@@ -309,6 +315,7 @@ export function IngredientForm(props: IngredientFormProps) {
                   </label>
                   <div className={'join'}>
                     <input
+                      id={'anotherVolume'}
                       type={'number'}
                       className={`input input-sm join-item input-bordered w-full ${errors.volume && touched.volume && 'input-error'}`}
                       value={values.volume}
@@ -395,12 +402,12 @@ export function IngredientForm(props: IngredientFormProps) {
           </FieldArray>
 
           <div>
-            <label className={'label'}>
+            <div className={'label'}>
               <span className={'label-text'}>Tags</span>
               <span className={'label-text-alt text-error'}>
                 <>{errors.tags && touched.tags && errors.tags}</>
               </span>
-            </label>
+            </div>
             <TagsInput
               value={values.tags}
               onChange={(tags) =>
@@ -416,9 +423,9 @@ export function IngredientForm(props: IngredientFormProps) {
           </div>
           <div className={'col-span-2'}>
             {values.image != undefined ? (
-              <label className={'label'}>
+              <div className={'label'}>
                 <span className={'label-text'}>Zutaten Bild</span>
-              </label>
+              </div>
             ) : (
               <></>
             )}
@@ -458,7 +465,7 @@ export function IngredientForm(props: IngredientFormProps) {
             )}
           </div>
           <div className={'form-control'}>
-            <label className={'label'}>
+            <label className={'label'} htmlFor={'link'}>
               <span className={'label-text'}>Link</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
@@ -468,6 +475,7 @@ export function IngredientForm(props: IngredientFormProps) {
             </label>
             <div className={'join'}>
               <input
+                id={'link'}
                 type={'text'}
                 placeholder={''}
                 className={`input join-item input-bordered w-full ${errors.link && touched.link && 'input-error'}`}

--- a/components/modals/GlobalModal.tsx
+++ b/components/modals/GlobalModal.tsx
@@ -28,14 +28,18 @@ export function GlobalModal(props: GlobalModalProps) {
       <dialog id="globalModal" className="modal">
         <div className={`modal-box relative w-full p-1.5 md:max-w-2xl md:p-4`}>
           <form method="dialog">
-            <button className="btn btn-circle btn-outline btn-sm absolute right-2 top-2">
+            <div onClick={() => modalContext.closeModal()} className="btn btn-circle btn-outline btn-sm absolute right-2 top-2">
               <FaTimes />
-            </button>
+            </div>
           </form>
-          {modalContext.content}
+          {modalContext.content.map((content, index) => (
+            <div key={index} className={index == modalContext.content.length - 1 ? '' : 'hidden'}>
+              {content}
+            </div>
+          ))}
         </div>
         <form method="dialog" className="modal-backdrop">
-          <button>close</button>
+          <div onClick={() => modalContext.closeModal()}>close</div>
         </form>
       </dialog>
     </div>

--- a/components/modals/GlobalModal.tsx
+++ b/components/modals/GlobalModal.tsx
@@ -25,17 +25,19 @@ export function GlobalModal(props: GlobalModalProps) {
   return (
     <div>
       {props.children}
-      <input type="checkbox" id="globalModal" className="modal-toggle" />
-      <label htmlFor="globalModal" className="modal cursor-pointer">
-        <label className={`modal-box relative w-full p-1.5 md:max-w-2xl md:p-4`} htmlFor="">
-          <label htmlFor="globalModal" className="btn btn-circle btn-outline btn-sm absolute right-2 top-2">
-            <FaTimes />
-          </label>
-          <label className={''} htmlFor="">
-            {modalContext.content}
-          </label>
-        </label>
-      </label>
+      <dialog id="globalModal" className="modal">
+        <div className={`modal-box relative w-full p-1.5 md:max-w-2xl md:p-4`}>
+          <form method="dialog">
+            <button className="btn btn-circle btn-outline btn-sm absolute right-2 top-2">
+              <FaTimes />
+            </button>
+          </form>
+          {modalContext.content}
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
     </div>
   );
 }

--- a/lib/context/ModalContextProvider.tsx
+++ b/lib/context/ModalContextProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
 interface ModalContextProps {
-  content: JSX.Element;
+  content: JSX.Element[];
 
   openModal: (content: JSX.Element) => void;
 
@@ -9,7 +9,7 @@ interface ModalContextProps {
 }
 
 export const ModalContext = createContext<ModalContextProps>({
-  content: <>{'N/A - Modal'}</>,
+  content: [],
   openModal: () => {},
   closeModal: () => {},
 });

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
     "tailwindcss": "3.4.7",
     "typescript": "5.5.3"
   },
-  "packageManager": "pnpm@9.1.0"
+  "packageManager": "pnpm@9.6.0"
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,8 +10,6 @@ import Head from 'next/head';
 import ThemeBoundary from '../components/layout/ThemeBoundary';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
-  const [modalContent, setModalContent] = useState(<></>);
-
   const [modalContentStack, setModalContentStack] = useState<JSX.Element[]>([]);
 
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
@@ -23,27 +21,28 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
       <AlertBoundary>
         <ModalContext.Provider
           value={{
-            content: modalContent,
+            content: modalContentStack,
             openModal: async (content) => {
               if ((document.getElementById('globalModal') as HTMLDialogElement)?.open == false) {
                 (document.getElementById('globalModal') as HTMLDialogElement).showModal();
               }
-              if (modalContent != <></>) {
-                setModalContentStack([...modalContentStack, modalContent]);
-              }
 
               // The await has the effect in chrome, that the modal was not replaces otherwise
-              await setModalContent(<></>);
-              setModalContent(content);
+              setModalContentStack([...modalContentStack, content]);
             },
             async closeModal() {
               if (modalContentStack.length > 0) {
-                setModalContent(modalContentStack.pop() as JSX.Element);
+                setModalContentStack(modalContentStack.slice(0, modalContentStack.length - 1));
+
+                if (modalContentStack.length == 1 && (document.getElementById('globalModal') as HTMLDialogElement | null)?.open == true) {
+                  (document.getElementById('globalModal') as HTMLDialogElement).close();
+                }
               } else {
-                if ((document.getElementById('globalModal') as HTMLDialogElement | null)?.open == true) {
+                if (modalContentStack.length == 0 && (document.getElementById('globalModal') as HTMLDialogElement | null)?.open == true) {
                   (document.getElementById('globalModal') as HTMLDialogElement).close();
                 }
               }
+
               forceUpdate();
             },
           }}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,8 @@ import ThemeBoundary from '../components/layout/ThemeBoundary';
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
   const [modalContent, setModalContent] = useState(<></>);
 
+  const [modalContentStack, setModalContentStack] = useState<JSX.Element[]>([]);
+
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
   const [theme, setTheme] = useState<'dark' | 'auto' | 'light'>('auto');
@@ -23,16 +25,24 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
           value={{
             content: modalContent,
             openModal: async (content) => {
-              if ((document.getElementById('globalModal') as any)?.checked == false) {
-                (document.querySelector('#globalModal') as any).checked = true;
+              if ((document.getElementById('globalModal') as HTMLDialogElement)?.open == false) {
+                (document.getElementById('globalModal') as HTMLDialogElement).showModal();
               }
+              if (modalContent != <></>) {
+                setModalContentStack([...modalContentStack, modalContent]);
+              }
+
               // The await has the effect in chrome, that the modal was not replaces otherwise
               await setModalContent(<></>);
               setModalContent(content);
             },
             async closeModal() {
-              if ((document.getElementById('globalModal') as HTMLInputElement | null)?.checked == true) {
-                (document.querySelector('#globalModal') as any).checked = false;
+              if (modalContentStack.length > 0) {
+                setModalContent(modalContentStack.pop() as JSX.Element);
+              } else {
+                if ((document.getElementById('globalModal') as HTMLDialogElement | null)?.open == true) {
+                  (document.getElementById('globalModal') as HTMLDialogElement).close();
+                }
               }
               forceUpdate();
             },


### PR DESCRIPTION
## Closing issues:

- Closes: #334 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Changed the modal method from checkbox (depr.) to the latest way to dialog tags. This resolves the issue, that the modal closes when hitting the backpane of the modal.

Added addititionally an modal stack. This prevents the modal from closing when opening another modal from within. 
