### PR TITLE
fix: scroll to top on search page when cocktail gets selected

### DIFF
--- a/pages/workspaces/[workspaceId]/search.tsx
+++ b/pages/workspaces/[workspaceId]/search.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CocktailRecipeFull } from '../../../models/CocktailRecipeFull';
 import CocktailRecipeCardItem from '../../../components/cocktails/CocktailRecipeCardItem';
 import { SearchModal } from '../../../components/modals/SearchModal';
+import { useRouter } from 'next/router';
 
 interface SearchPageProps {
   showImage?: boolean;
@@ -11,6 +12,12 @@ interface SearchPageProps {
 
 export default function SearchPage(props: SearchPageProps) {
   const [selectedCocktail, setSelectedCocktail] = useState<CocktailRecipeFull | undefined>(undefined);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [selectedCocktail]);
 
   return (
     <div className={'flex flex-col-reverse gap-2 md:flex-row'}>


### PR DESCRIPTION
## Closing issues:

- Closes: #357 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

When you scrolled down to find a cocktail, the page scrolls now back to the top, when a cocktail gets selected.

## Affected sites (please check during review):

- [ ] [worspaceId]/search - Scroll down and select a cocktail, the page scrolls now back to the top

