### PR TITLE
fix: mange xy head bar now sticky to the top

### DIFF
--- a/components/layout/ManageEntityLayout.tsx
+++ b/components/layout/ManageEntityLayout.tsx
@@ -26,8 +26,13 @@ export function ManageEntityLayout(props: ManageEntityLayoutProps) {
       <Head>
         <>{typeof props.title === 'string' ? <title>{`${props.title} - The Cocktail-Manager`}</title> : <title>The Cocktail-Manager</title>}</>
       </Head>
-      <div className={'flex flex-col p-1 md:p-4 print:p-1'}>
-        <div className={'grid w-full grid-cols-3 items-center justify-center justify-items-center print:grid-cols-1'}>
+      <div>
+        {/*<div className={'flex flex-col p-1 md:p-4 print:p-1'}>*/}
+        <div
+          className={
+            'sticky top-0 z-10 grid w-full grid-cols-3 items-center justify-center justify-items-center bg-base-100 p-1 md:p-2 print:grid-cols-1 print:p-1'
+          }
+        >
           <div className={'col-span-1 justify-self-start print:hidden'}>
             <div
               className={'btn btn-square btn-primary btn-sm md:btn-md'}
@@ -55,7 +60,7 @@ export function ManageEntityLayout(props: ManageEntityLayoutProps) {
             {props.actions}
           </div>
         </div>
-        <div className={'p-2 md:p-8 print:p-2'}>{props.children}</div>
+        <div className={'p-2 md:p-4 print:p-2'}>{props.children}</div>
       </div>
     </>
   );


### PR DESCRIPTION
## Closing issues:

- Closes: #361 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

When using a tablet, and you want to navigate with the buttons you have to scroll a lot, this issue fixes this by making the headbar sticky.

## Affected sites (please check during review):

- [ ] [workspaceId]/mange/<cocktails|ingredients|glasses|garnishes|cards|...>/index.tsx - Sticky at the top
- [ ] [workspaceId]/mange/<cocktails|ingredients|glasses|garnishes|cards|...>/<create|id>.tsx - Sticky at the top
