### PR TITLE
feat: 'new version' popup at workspace selection page after new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "http-method-enum": "1.0.0",
     "jssoup": "0.0.15",
     "lodash": "4.17.21",
+    "marked": "^14.0.0",
     "next": "14.2.5",
     "next-auth": "4.24.7",
     "node-html-parser": "6.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
+      marked:
+        specifier: ^14.0.0
+        version: 14.0.0
       next:
         specifier: 14.2.5
         version: 14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2004,6 +2007,11 @@ packages:
 
   marked@12.0.2:
     resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -5388,6 +5396,8 @@ snapshots:
       supports-hyperlinks: 3.0.0
 
   marked@12.0.2: {}
+
+  marked@14.0.0: {}
 
   mdast-util-from-markdown@2.0.0:
     dependencies:

--- a/prisma/migrations/20240812120204_notify_new_version/migration.sql
+++ b/prisma/migrations/20240812120204_notify_new_version/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Setting" ADD VALUE 'lastSeenVersion';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ enum Setting {
   theme
   showStatisticActions
   showQueueAsOverlay
+  lastSeenVersion
 }
 
 enum WorkspaceSettingKey {


### PR DESCRIPTION
## Closing issues:

- Closes: #170 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Until now it was not really shown, that a new version was relesed. This PR solves this by showing a popup once after a new release was published. Therefor each user has a custom setting property with the last version he saw. 

## Affected sites (please check during review):

- [x] index.tsx - Changelog popup once, after showing the user setting gets refreshed
