### PR TITLE
fix: Statistic date input behavior

### DIFF
--- a/pages/workspaces/[workspaceId]/manage/statistics/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/statistics/index.tsx
@@ -114,10 +114,12 @@ export default function StatisticsPage() {
           <input
             className={'input input-bordered'}
             type={'date'}
-            value={startDate.toISOString().split('T')[0]}
+            value={new Date(startDate).toISOString().split('T')[0]}
             onChange={async (event) => {
+              if (!event.target.value) return;
               const start = new Date(event.target.value);
               let end = endDate;
+
               if (start.getTime() > end.getTime()) {
                 end = start;
                 setEndDate(start);
@@ -144,6 +146,7 @@ export default function StatisticsPage() {
             type={'date'}
             value={endDate.toISOString().split('T')[0]}
             onChange={async (event) => {
+              if (!event.target.value) return;
               const end = new Date(event.target.value);
               let start = startDate;
               if (end.getTime() < startDate.getTime()) {

--- a/styles/global.css
+++ b/styles/global.css
@@ -23,7 +23,7 @@
 }
 
 .table > thead {
-  @apply bg-base-100;
+    /*@apply bg-base-100;*/
 }
 
 .divider-sm {

--- a/styles/global.css
+++ b/styles/global.css
@@ -23,7 +23,7 @@
 }
 
 .table > thead {
-    /*@apply bg-base-100;*/
+  /*@apply bg-base-100;*/
 }
 
 .divider-sm {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,8 +16,10 @@ module.exports = {
   daisyui: {
     themes: [
       'autumn',
+      'halloween',
       {
         halloween: {
+          ...require('daisyui/src/theming/themes')['halloween'],
           primary: '#f28c18',
           secondary: '#B51288',
           accent: '#51a800',
@@ -30,10 +32,6 @@ module.exports = {
         },
       },
     ],
-    darkTheme: 'halloween', // name of one of the included themes for dark mode
+    darkTheme: 'halloween',
   },
 };
-// module.exports = {
-//     content: ['./pages/**/*.{js,ts,jsx,tsx}'],
-//     plugins: [require('daisyui')],
-// };


### PR DESCRIPTION
## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

When entering 0 to the statistic page date selection, the parsing failed some times.

## Affected sites (please check during review):

- [ ] [workspaceId]/manage/statistics - Input field fixed when entering 0, fixed dark calendar icon now properly displayed in chrome
