### PR TITLE
fix: Calculation creation and deletion errors solved, set shopping unit preselection if only one is available 

### DIFF
--- a/components/cocktails/CocktailRecipeForm.tsx
+++ b/components/cocktails/CocktailRecipeForm.tsx
@@ -655,6 +655,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     showInfo={false}
                     showTags={true}
                     showImage={true}
+                    showDescription={true}
                   />
                 </div>
               </div>

--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -203,7 +203,7 @@ export function IngredientForm(props: IngredientFormProps) {
 
           <div className={'form-control'}>
             <label className={'label'} htmlFor={'description'}>
-              <span className={'label-text'}>Allg. Beschreibung</span>
+              <span className={'label-text'}>Produktbeschreibung</span>
               <span className={'label-text-alt space-x-2 text-error'}>
                 <span>
                   <>{errors.description && touched.description && errors.description}</>

--- a/pages/api/workspaces/[workspaceId]/calculations/index.tsx
+++ b/pages/api/workspaces/[workspaceId]/calculations/index.tsx
@@ -49,7 +49,7 @@ export default withHttpMethods({
       ingredientShoppingUnits: {
         create: ingredientShoppingUnits.map((ingredientShoppingUnit: any) => ({
           ingredient: { connect: { id: ingredientShoppingUnit.ingredientId } },
-          unitId: { connect: { id: ingredientShoppingUnit.unitId } },
+          unit: { connect: { id: ingredientShoppingUnit.unitId } },
           checked: ingredientShoppingUnit.checked,
         })),
       },

--- a/pages/workspaces/[workspaceId]/manage/calculations/[id].tsx
+++ b/pages/workspaces/[workspaceId]/manage/calculations/[id].tsx
@@ -956,7 +956,11 @@ export default function CalculationPage() {
                                   className={'select select-sm'}
                                   value={
                                     ingredientShoppingUnits.find((ingredientShoppingUnit) => ingredientShoppingUnit.ingredientId == items[0].ingredient.id)
-                                      ?.unitId ?? ''
+                                      ?.unitId ??
+                                    // if only one unit is available, select it
+                                    (ingredients.find((ingredient) => ingredient.id == items[0].ingredient.id)?.IngredientVolume.length == 1
+                                      ? ingredients.find((ingredient) => ingredient.id == items[0].ingredient.id)?.IngredientVolume[0].unitId
+                                      : '')
                                   }
                                   onChange={(event) => {
                                     const updatedItems = ingredientShoppingUnits.filter((item) => item.ingredientId != items[0].ingredient.id);

--- a/pages/workspaces/[workspaceId]/manage/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/index.tsx
@@ -96,7 +96,7 @@ export default function ManagePage() {
           <ManageCard icon={<PiBeerBottleBold />} title={'Zutaten'} link={`/workspaces/${workspaceId}/manage/ingredients`} />
           <ManageCard icon={<LuCitrus />} title={'Garnituren'} link={`/workspaces/${workspaceId}/manage/garnishes`} />
           <ManageCard icon={<FaGlassMartiniAlt />} title={'Gläser'} link={`/workspaces/${workspaceId}/manage/glasses`} />
-          <ManageCard icon={<FaCalculator />} title={'Kalkulation'} link={`/workspaces/${workspaceId}/manage/calculations`} />
+          <ManageCard icon={<FaCalculator />} title={'Mengen-Kalkulation'} link={`/workspaces/${workspaceId}/manage/calculations`} />
           <ManageCard icon={<IoMdStats />} title={'Statistiken'} link={`/workspaces/${workspaceId}/manage/statistics`} />
           <ManageCard icon={<FaGear />} title={'Einstellungen'} link={`/workspaces/${workspaceId}/manage/settings`} />
         </div>

--- a/pages/workspaces/[workspaceId]/manage/ingredients/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/ingredients/index.tsx
@@ -120,7 +120,7 @@ export default function IngredientsOverviewPage() {
                               modalContext.openModal(
                                 <div className={'flex flex-col gap-2'}>
                                   <div className={'text-2xl font-bold'}>{ingredient.name}</div>
-                                  <div className={'text-lg font-bold'}>Allgemeine Beschreibung</div>
+                                  <div className={'text-lg font-bold'}>Produktbeschreibung</div>
                                   <div className={'whitespace-pre-wrap text-justify'}>{ingredient.description ?? '-'}</div>
                                   <div className={'text-lg font-bold'}>Notizen</div>
                                   <div className={'whitespace-pre-wrap text-justify'}>{ingredient.notes ?? '-'}</div>

--- a/prisma/migrations/20240826113333_fixed_calculation_constraint/migration.sql
+++ b/prisma/migrations/20240826113333_fixed_calculation_constraint/migration.sql
@@ -1,0 +1,7 @@
+-- DropForeignKey
+ALTER TABLE "CalculationIngredientShoppingUnit"
+    DROP CONSTRAINT "CalculationIngredientShoppingUnit_cocktailCalculationId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "CalculationIngredientShoppingUnit"
+    ADD CONSTRAINT "CalculationIngredientShoppingUnit_cocktailCalculationId_fkey" FOREIGN KEY ("cocktailCalculationId") REFERENCES "CocktailCalculation" ("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -395,7 +395,7 @@ model CalculationIngredientShoppingUnit {
 
   checked Boolean @default(false)
 
-  CocktailCalculation   CocktailCalculation @relation(fields: [cocktailCalculationId], references: [id])
+  CocktailCalculation   CocktailCalculation @relation(fields: [cocktailCalculationId], references: [id], onDelete: Cascade)
   cocktailCalculationId String
 
   @@id([ingredientId, unitId, cocktailCalculationId])


### PR DESCRIPTION
## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

When saving an calculation for the first time, an error was thrown (wrong db query). Thats now solved.
If only one unit is available, this one gets preselected at the calculation shopping list unit.

## Affected sites (please check during review):

- [ ] [workspaceId]/manage/calculations/[id] - Shopping list unit now preselected if only one is available, delete and create api handling fixed
