### PR TITLE
fix: Cocktail recipe card loading behavior improved 

### DIFF
--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -10,7 +10,7 @@ import { Loading } from '../Loading';
 import { fetchCocktail } from '../../lib/network/cocktails';
 
 interface CocktailRecipeOverviewItemProps {
-  cocktailRecipe: CocktailRecipeFull;
+  cocktailRecipe: CocktailRecipeFull | string;
   showImage?: boolean;
   specialPrice?: number;
   showPrice?: boolean;
@@ -29,16 +29,18 @@ export default function CocktailRecipeCardItem(props: CocktailRecipeOverviewItem
   const [submittingStatistic, setSubmittingStatistic] = useState(false);
   const [submittingQueue, setSubmittingQueue] = useState(false);
 
-  const [cocktailRecipe, setCocktailRecipe] = useState<CocktailRecipeFull | undefined>(
+  const [loadedCocktailRecipe, setLoadedCocktailRecipe] = useState<CocktailRecipeFull | undefined>(
     typeof props.cocktailRecipe === 'string' ? undefined : props.cocktailRecipe,
   );
   const [cocktailRecipeLoading, setCocktailRecipeLoading] = useState(false);
 
   useEffect(() => {
     if (typeof props.cocktailRecipe === 'string') {
-      fetchCocktail(workspaceId, props.cocktailRecipe, setCocktailRecipe, setCocktailRecipeLoading);
+      fetchCocktail(workspaceId, props.cocktailRecipe, setLoadedCocktailRecipe, setCocktailRecipeLoading);
     }
   }, [workspaceId, props.cocktailRecipe]);
+
+  const cocktailRecipe = typeof props.cocktailRecipe === 'string' ? loadedCocktailRecipe : props.cocktailRecipe;
 
   return (
     <div className={'col-span-1'}>

--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -1,11 +1,13 @@
 import { CocktailRecipeFull } from '../../models/CocktailRecipeFull';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CompactCocktailRecipeInstruction } from './CompactCocktailRecipeInstruction';
 import { ShowCocktailInfoButton } from './ShowCocktailInfoButton';
 import { useRouter } from 'next/router';
-import { FaPlus } from 'react-icons/fa';
+import { FaExclamationTriangle, FaPlus } from 'react-icons/fa';
 import { MdPlaylistAdd } from 'react-icons/md';
 import { addCocktailToQueue, addCocktailToStatistic } from '../../lib/network/cocktailTracking';
+import { Loading } from '../Loading';
+import { fetchCocktail } from '../../lib/network/cocktails';
 
 interface CocktailRecipeOverviewItemProps {
   cocktailRecipe: CocktailRecipeFull;
@@ -22,95 +24,121 @@ interface CocktailRecipeOverviewItemProps {
 
 export default function CocktailRecipeCardItem(props: CocktailRecipeOverviewItemProps) {
   const router = useRouter();
+  const workspaceId = router.query.workspaceId as string;
 
   const [submittingStatistic, setSubmittingStatistic] = useState(false);
   const [submittingQueue, setSubmittingQueue] = useState(false);
 
+  const [cocktailRecipe, setCocktailRecipe] = useState<CocktailRecipeFull | undefined>(
+    typeof props.cocktailRecipe === 'string' ? undefined : props.cocktailRecipe,
+  );
+  const [cocktailRecipeLoading, setCocktailRecipeLoading] = useState(false);
+
+  useEffect(() => {
+    if (typeof props.cocktailRecipe === 'string') {
+      fetchCocktail(workspaceId, props.cocktailRecipe, setCocktailRecipe, setCocktailRecipeLoading);
+    }
+  }, [workspaceId, props.cocktailRecipe]);
+
   return (
     <div className={'col-span-1'}>
       <div className={'card card-side h-full'}>
-        <ShowCocktailInfoButton showInfo={props.showInfo ?? false} cocktailRecipe={props.cocktailRecipe} />
-        <div className={'card-body'}>
-          <CompactCocktailRecipeInstruction
-            specialPrice={props.specialPrice}
-            showImage={props.showImage ?? false}
-            showPrice={props.showPrice ?? true}
-            cocktailRecipe={props.cocktailRecipe}
-            image={props.image}
-          />
+        {cocktailRecipeLoading ? (
+          <div className={'flex h-full min-h-40 w-full flex-col items-center justify-center gap-2'}>
+            <Loading />
+            <div>Lade Cocktail...</div>
+          </div>
+        ) : cocktailRecipe ? (
           <>
-            {props.showNotes && props.cocktailRecipe.notes && (
+            <ShowCocktailInfoButton showInfo={props.showInfo ?? false} cocktailRecipe={cocktailRecipe} />
+            <div className={'card-body'}>
+              <CompactCocktailRecipeInstruction
+                cocktailRecipe={cocktailRecipe}
+                specialPrice={props.specialPrice}
+                showImage={props.showImage ?? false}
+                showPrice={props.showPrice ?? true}
+                image={props.image}
+              />
               <>
-                <div className={'border-b border-base-100'}></div>
-                <div className={'font-bold'}>Zubereitungsnotizen</div>
-                <div className={'long-text-format'}>{props.cocktailRecipe.notes}</div>
+                {props.showNotes && cocktailRecipe.notes && (
+                  <>
+                    <div className={'border-b border-base-100'}></div>
+                    <div className={'font-bold'}>Zubereitungsnotizen</div>
+                    <div className={'long-text-format'}>{cocktailRecipe.notes}</div>
+                  </>
+                )}
+                {props.showDescription && cocktailRecipe.description && (
+                  <>
+                    <div className={'border-b border-base-100'}></div>
+                    <div className={'font-bold'}>Allgemeine Beschreibung</div>
+                    <div className={'long-text-format'}>{cocktailRecipe.description}</div>
+                  </>
+                )}
+
+                <div className={'h-full'}></div>
+
+                {props.showTags && cocktailRecipe.tags.length > 0 ? (
+                  <div className={''}>
+                    <div className={'mb-2 border-b border-base-100'}></div>
+                    {cocktailRecipe.tags.map((tag) => (
+                      <span key={`cocktail-overview-item-${cocktailRecipe.id}-tag-${tag}`} className={'badge badge-primary badge-outline mr-1'}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <></>
+                )}
+
+                {props.showStatisticActions ? (
+                  <div className={''}>
+                    <div className={'mt-1 flex flex-row gap-2'}>
+                      <button
+                        className={'btn btn-outline flex-1'}
+                        onClick={() =>
+                          addCocktailToQueue({
+                            workspaceId: router.query.workspaceId as string,
+                            cocktailId: cocktailRecipe.id,
+                            setSubmitting: setSubmittingQueue,
+                          })
+                        }
+                        disabled={submittingQueue}
+                      >
+                        <MdPlaylistAdd />
+                        Liste
+                        {submittingQueue ? <span className={'loading loading-spinner'}></span> : <></>}
+                      </button>
+                      <button
+                        className={'btn btn-outline btn-primary flex-1'}
+                        onClick={() =>
+                          addCocktailToStatistic({
+                            workspaceId: router.query.workspaceId as string,
+                            cocktailId: cocktailRecipe.id,
+                            cardId: router.query.cardId,
+                            actionSource: 'CARD',
+                            setSubmitting: setSubmittingStatistic,
+                          })
+                        }
+                        disabled={submittingStatistic}
+                      >
+                        <FaPlus />
+                        Gemacht
+                        {submittingStatistic ? <span className={'loading loading-spinner'}></span> : <></>}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <></>
+                )}
               </>
-            )}
-            {props.showDescription && props.cocktailRecipe.description && (
-              <>
-                <div className={'border-b border-base-100'}></div>
-                <div className={'font-bold'}>Allgemeine Beschreibung</div>
-                <div className={'long-text-format'}>{props.cocktailRecipe.description}</div>
-              </>
-            )}
-
-            <div className={'h-full'}></div>
-
-            {props.showTags && props.cocktailRecipe.tags.length > 0 ? (
-              <div className={''}>
-                <div className={'mb-2 border-b border-base-100'}></div>
-                {props.cocktailRecipe.tags.map((tag) => (
-                  <span key={`cocktail-overview-item-${props.cocktailRecipe.id}-tag-${tag}`} className={'badge badge-primary badge-outline mr-1'}>
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            ) : (
-              <></>
-            )}
-
-            {props.showStatisticActions ? (
-              <div className={''}>
-                <div className={'mt-1 flex flex-row gap-2'}>
-                  <button
-                    className={'btn btn-outline flex-1'}
-                    onClick={() =>
-                      addCocktailToQueue({
-                        workspaceId: router.query.workspaceId as string,
-                        cocktailId: props.cocktailRecipe.id,
-                        setSubmitting: setSubmittingQueue,
-                      })
-                    }
-                    disabled={submittingQueue}
-                  >
-                    <MdPlaylistAdd />
-                    Liste
-                    {submittingQueue ? <span className={'loading loading-spinner'}></span> : <></>}
-                  </button>
-                  <button
-                    className={'btn btn-outline btn-primary flex-1'}
-                    onClick={() =>
-                      addCocktailToStatistic({
-                        workspaceId: router.query.workspaceId as string,
-                        cocktailId: props.cocktailRecipe.id,
-                        cardId: router.query.cardId,
-                        actionSource: 'CARD',
-                        setSubmitting: setSubmittingStatistic,
-                      })
-                    }
-                    disabled={submittingStatistic}
-                  >
-                    <FaPlus />
-                    Gemacht
-                    {submittingStatistic ? <span className={'loading loading-spinner'}></span> : <></>}
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <></>
-            )}
+            </div>
           </>
-        </div>
+        ) : (
+          <div className={'flex h-full min-h-40 w-full flex-col items-center justify-center gap-2'}>
+            <FaExclamationTriangle />
+            <div>Fehler beim Laden des Cocktails</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/lib/network/cocktailRatings.ts
+++ b/lib/network/cocktailRatings.ts
@@ -1,0 +1,39 @@
+import { alertService } from '../alertService';
+import { CocktailRating } from '@prisma/client';
+
+export function fetchCocktailRatings(
+  workspaceId: string | string[] | undefined,
+  cocktailId: string,
+  setCocktailRatings: (ratings: CocktailRating[]) => void,
+  setCocktailRatingLoading: (loading: boolean) => void,
+  setCocktailRatingError: (hasError: boolean) => void,
+) {
+  if (!workspaceId) return;
+  setCocktailRatingLoading(true);
+  fetch(`/api/workspaces/${workspaceId}/cocktails/${cocktailId}/ratings`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then(async (response) => {
+      if (response.ok) {
+        const body = await response.json();
+        setCocktailRatings(body.data);
+        setCocktailRatingError(false);
+      } else {
+        const body = await response.json();
+        alertService.error(body.message ?? 'Fehler beim Laden der Cocktail Bewertungen', response.status, response.statusText);
+        setCocktailRatings([]);
+        setCocktailRatingError(true);
+      }
+    })
+    .catch((error) => {
+      console.error('fetchCocktailRatings', error);
+      alertService.error('Es ist ein Fehler aufgetreten');
+      setCocktailRatingError(true);
+    })
+    .finally(() => {
+      setCocktailRatingLoading(false);
+    });
+}

--- a/lib/network/cocktails.ts
+++ b/lib/network/cocktails.ts
@@ -1,5 +1,6 @@
 import { alertService } from '../alertService';
 import { CocktailRecipeFull } from '../../models/CocktailRecipeFull';
+import { CocktailRecipeFullWithImage } from '../../models/CocktailRecipeFullWithImage';
 
 export function fetchCocktail(
   workspaceId: string | string[] | undefined,
@@ -10,6 +11,33 @@ export function fetchCocktail(
   if (!workspaceId) return;
   setCocktailLoading(true);
   fetch(`/api/workspaces/${workspaceId}/cocktails/${cocktailId}`)
+    .then(async (response) => {
+      const body = await response.json();
+      if (response.ok) {
+        setCocktail(body.data);
+      } else {
+        console.error('fetchCocktail', response);
+        alertService.error(body.message ?? 'Fehler beim Laden des Cocktails', response.status, response.statusText);
+      }
+    })
+    .catch((error) => {
+      console.error('fetchCocktail', error);
+      alertService.error('Fehler beim Laden des Cocktails');
+    })
+    .finally(() => {
+      setCocktailLoading(false);
+    });
+}
+
+export function fetchCocktailWithImage(
+  workspaceId: string | string[] | undefined,
+  cocktailId: string,
+  setCocktail: (cocktail: CocktailRecipeFullWithImage) => void,
+  setCocktailLoading: (loading: boolean) => void,
+) {
+  if (!workspaceId) return;
+  setCocktailLoading(true);
+  fetch(`/api/workspaces/${workspaceId}/cocktails/${cocktailId}?include=image`)
     .then(async (response) => {
       const body = await response.json();
       if (response.ok) {

--- a/lib/network/cocktails.ts
+++ b/lib/network/cocktails.ts
@@ -1,0 +1,29 @@
+import { alertService } from '../alertService';
+import { CocktailRecipeFull } from '../../models/CocktailRecipeFull';
+
+export function fetchCocktail(
+  workspaceId: string | string[] | undefined,
+  cocktailId: string,
+  setCocktail: (cocktail: CocktailRecipeFull) => void,
+  setCocktailLoading: (loading: boolean) => void,
+) {
+  if (!workspaceId) return;
+  setCocktailLoading(true);
+  fetch(`/api/workspaces/${workspaceId}/cocktails/${cocktailId}`)
+    .then(async (response) => {
+      const body = await response.json();
+      if (response.ok) {
+        setCocktail(body.data);
+      } else {
+        console.error('fetchCocktail', response);
+        alertService.error(body.message ?? 'Fehler beim Laden des Cocktails', response.status, response.statusText);
+      }
+    })
+    .catch((error) => {
+      console.error('fetchCocktail', error);
+      alertService.error('Fehler beim Laden des Cocktails');
+    })
+    .finally(() => {
+      setCocktailLoading(false);
+    });
+}

--- a/models/CocktailCardFull.tsx
+++ b/models/CocktailCardFull.tsx
@@ -4,36 +4,7 @@ export type CocktailCardFull = Prisma.CocktailCardGetPayload<{
   include: {
     groups: {
       include: {
-        items: {
-          include: {
-            cocktail: {
-              include: {
-                ice: true;
-                glass: { include: { _count: { select: { GlassImage: true } } } };
-                garnishes: {
-                  include: {
-                    garnish: { include: { _count: { select: { GarnishImage: true } } } };
-                  };
-                };
-                _count: { select: { CocktailRecipeImage: true } };
-                steps: {
-                  include: {
-                    action: true;
-                    ingredients: {
-                      include: {
-                        ingredient: {
-                          include: { _count: { select: { IngredientImage: true } } };
-                          unit: true;
-                        };
-                      };
-                    };
-                  };
-                };
-                ratings: true;
-              };
-            };
-          };
-        };
+        items: true;
       };
     };
   };

--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,10 @@ const withPWA = require('next-pwa')({
       handler: 'NetworkOnly', // don't cache queue requests, always fetch from network
     },
     {
+      urlPattern: /\/ratings$/,
+      handler: 'NetworkOnly', // don't cache queue requests, always fetch from network
+    },
+    {
       urlPattern: /^https?.*/,
       handler: 'StaleWhileRevalidate', // always cache first, but go to network (if available) for new data and update cache
       method: 'GET', // only cache GET requests

--- a/pages/api/workspaces/[workspaceId]/cards/[cardId]/index.tsx
+++ b/pages/api/workspaces/[workspaceId]/cards/[cardId]/index.tsx
@@ -22,33 +22,7 @@ export default withHttpMethods({
       include: {
         groups: {
           include: {
-            items: {
-              include: {
-                cocktail: {
-                  include: {
-                    _count: { select: { CocktailRecipeImage: true } },
-                    ice: true,
-                    glass: { include: { _count: { select: { GlassImage: true } } } },
-                    garnishes: {
-                      include: {
-                        garnish: true,
-                      },
-                    },
-                    steps: {
-                      include: {
-                        action: true,
-                        ingredients: {
-                          include: {
-                            ingredient: true,
-                            unit: true,
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
+            items: true,
           },
         },
       },

--- a/pages/api/workspaces/[workspaceId]/cards/index.tsx
+++ b/pages/api/workspaces/[workspaceId]/cards/index.tsx
@@ -32,33 +32,7 @@ export default withHttpMethods({
       include: {
         groups: {
           include: {
-            items: {
-              include: {
-                cocktail: {
-                  include: {
-                    _count: { select: { CocktailRecipeImage: true } },
-                    ice: true,
-                    glass: true,
-                    garnishes: {
-                      include: {
-                        garnish: true,
-                      },
-                    },
-                    steps: {
-                      include: {
-                        action: true,
-                        ingredients: {
-                          include: {
-                            ingredient: true,
-                            unit: true,
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
+            items: true,
           },
         },
       },

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -437,7 +437,7 @@ export default function OverviewPage() {
                                     showInfo={true}
                                     showPrice={groupItem.specialPrice == undefined && group.groupPrice == undefined}
                                     specialPrice={groupItem.specialPrice ?? group.groupPrice ?? undefined}
-                                    cocktailRecipe={groupItem.cocktail}
+                                    cocktailRecipe={groupItem.cocktail.id}
                                     showStatisticActions={showStatisticActions}
                                     showDescription={showDescription}
                                     showNotes={showNotes}

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -428,7 +428,7 @@ export default function OverviewPage() {
                           group.items
                             ?.sort((a, b) => a.itemNumber - b.itemNumber)
                             .map((groupItem, index) => {
-                              if (groupItem.cocktail != undefined) {
+                              if (groupItem.cocktailId != undefined) {
                                 return (
                                   <CocktailRecipeCardItem
                                     key={`card-${selectedCard.id}-group-${group.id}-cocktail-${groupItem.cocktailId}-${index}`}
@@ -437,7 +437,7 @@ export default function OverviewPage() {
                                     showInfo={true}
                                     showPrice={groupItem.specialPrice == undefined && group.groupPrice == undefined}
                                     specialPrice={groupItem.specialPrice ?? group.groupPrice ?? undefined}
-                                    cocktailRecipe={groupItem.cocktail.id}
+                                    cocktailRecipe={groupItem.cocktailId}
                                     showStatisticActions={showStatisticActions}
                                     showDescription={showDescription}
                                     showNotes={showNotes}

--- a/pages/workspaces/[workspaceId]/manage/cards/[id].tsx
+++ b/pages/workspaces/[workspaceId]/manage/cards/[id].tsx
@@ -369,7 +369,7 @@ function EditCocktailCard() {
                           <div className={'pt-2'}>
                             <FieldArray name={`groups.${groupIndex}.items`}>
                               {({ push: pushItem, remove: removeItem }) => (
-                                <div className={'grid grid-cols-1 gap-2 md:grid-cols-3'}>
+                                <div className={'grid grid-cols-1 gap-2 md:grid-cols-5 lg:grid-cols-7'}>
                                   {values.groups[groupIndex].items
                                     .sort((a, b) => a.itemNumber - b.itemNumber)
                                     .map((item, itemIndex) => (
@@ -450,7 +450,7 @@ function EditCocktailCard() {
                                         </div>
                                       </div>
                                     ))}
-                                  <div className={'col-span-1 flex flex-row justify-end md:col-span-3'}>
+                                  <div className={'col-span-full flex flex-row justify-end'}>
                                     {!card?.archived ? (
                                       <button
                                         type="button"

--- a/pages/workspaces/[workspaceId]/manage/cocktails/[id].tsx
+++ b/pages/workspaces/[workspaceId]/manage/cocktails/[id].tsx
@@ -12,6 +12,7 @@ import { PageCenter } from '../../../../../components/layout/PageCenter';
 import { UserContext } from '../../../../../lib/context/UserContextProvider';
 import { ModalContext } from '../../../../../lib/context/ModalContextProvider';
 import { NotSavedArchiveConfirmation } from '../../../../../components/modals/NotSavedArchiveConfirmation';
+import { fetchCocktailWithImage } from '../../../../../lib/network/cocktails';
 
 function EditCocktailRecipe() {
   const router = useRouter();
@@ -27,27 +28,8 @@ function EditCocktailRecipe() {
   const formRef: any = useRef<FormikProps<any>>(null);
 
   useEffect(() => {
-    if (!id) return;
-    if (!workspaceId) return;
-    setLoading(true);
-    fetch(`/api/workspaces/${workspaceId}/cocktails/${id}`)
-      .then(async (response) => {
-        const body = await response.json();
-        if (response.ok) {
-          setCocktailRecipe(body.data);
-        } else {
-          console.error('CocktailId -> fetchCocktail', response);
-          alertService.error(body.message ?? 'Fehler beim Laden des Cocktails', response.status, response.statusText);
-        }
-      })
-      .catch((error) => {
-        console.error('CocktailId -> fetchCocktail', error);
-        alertService.error('Fehler beim Laden des Cocktails');
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [id, workspaceId]);
+    fetchCocktailWithImage(workspaceId as string, id as string, setCocktailRecipe, setLoading);
+  }, []);
 
   return loading ? (
     <PageCenter>


### PR DESCRIPTION
As mentioned in #406 it would be better to fetch each cocktail itself to cache them easily.

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Changed the cocktail card item to fetch the cocktail instead of loading all cocktails during the card loading.

## Affected sites (please check during review):

- [ ] [workspaceId]/index
  - Each card loads the cocktail itself
  - Cocktail Detail Modals fetches Ratings independent
- [ ] [workspaceId]/manage/cocktails/<create|id>
  - Cocktail card works withouth loading and shows form changes
