### PR TITLE
fix: Made long notes, history, and description fields collapsible

### DIFF
--- a/components/ExpandableText.tsx
+++ b/components/ExpandableText.tsx
@@ -29,7 +29,7 @@ const ExpandableText = forwardRef<ExpandableTextHandle, ExpandableTextProps>(({ 
   return (
     <details className="group">
       <summary className={`${isClamped ? 'cursor-pointer' : ''} flex w-full list-none flex-col`}>
-        <div ref={textRef} className="line-clamp-3 text-justify group-open:line-clamp-none">
+        <div ref={textRef} className="long-text-format line-clamp-3 group-open:line-clamp-none">
           {text}
         </div>
         {isClamped && (

--- a/components/ExpandableText.tsx
+++ b/components/ExpandableText.tsx
@@ -1,18 +1,29 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 interface ExpandableTextProps {
   text: string;
-  resized?: void;
 }
 
-const ExpandableText = ({ text, resized }: ExpandableTextProps) => {
-  const textRef = useRef<HTMLDivElement | null>(null);
+export interface ExpandableTextHandle {
+  recalculateClamp: () => void;
+}
+
+const ExpandableText = forwardRef<ExpandableTextHandle, ExpandableTextProps>(({ text }, ref) => {
+  const textRef = useRef<HTMLDivElement | null>(null); // Typisiert als HTMLDivElement
   const [isClamped, setIsClamped] = useState(false);
 
-  useEffect(() => {
+  const checkClamp = () => {
     if (textRef.current) {
       setIsClamped(textRef.current.scrollHeight > textRef.current.clientHeight);
     }
+  };
+
+  useImperativeHandle(ref, () => ({
+    recalculateClamp: checkClamp,
+  }));
+
+  useEffect(() => {
+    checkClamp();
   }, [text]);
 
   return (
@@ -30,6 +41,8 @@ const ExpandableText = ({ text, resized }: ExpandableTextProps) => {
       </summary>
     </details>
   );
-};
+});
+
+ExpandableText.displayName = 'ExpandableText';
 
 export default ExpandableText;

--- a/components/ExpandableText.tsx
+++ b/components/ExpandableText.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface ExpandableTextProps {
+  text: string;
+  resized?: void;
+}
+
+const ExpandableText = ({ text, resized }: ExpandableTextProps) => {
+  const textRef = useRef<HTMLDivElement | null>(null);
+  const [isClamped, setIsClamped] = useState(false);
+
+  useEffect(() => {
+    if (textRef.current) {
+      setIsClamped(textRef.current.scrollHeight > textRef.current.clientHeight);
+    }
+  }, [text]);
+
+  return (
+    <details className="group">
+      <summary className={`${isClamped ? 'cursor-pointer' : ''} flex w-full list-none flex-col`}>
+        <div ref={textRef} className="line-clamp-3 text-justify group-open:line-clamp-none">
+          {text}
+        </div>
+        {isClamped && (
+          <>
+            <div className="w-full p-1 text-center underline group-open:hidden">mehr anzeigen</div>
+            <div className="hidden p-1 text-center underline group-open:inline">weniger anzeigen</div>
+          </>
+        )}
+      </summary>
+    </details>
+  );
+};
+
+export default ExpandableText;

--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -9,6 +9,7 @@ import { fetchCocktail } from '../../lib/network/cocktails';
 import { CocktailRating } from '@prisma/client';
 import { fetchCocktailRatings } from '../../lib/network/cocktailRatings';
 import StatisticActions from '../StatisticActions';
+import ExpandableText from '../ExpandableText';
 
 export type CocktailRecipeOverviewItemRef = {
   refresh: () => void;
@@ -90,21 +91,30 @@ const CocktailRecipeCardItem = forwardRef<CocktailRecipeOverviewItemRef, Cocktai
                   <>
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Zubereitungsnotizen</div>
-                    <div className={'long-text-format'}>{cocktailRecipe.notes}</div>
+                    <div className={'pl-2'}>
+                      <ExpandableText text={cocktailRecipe.notes} />
+                      {/*<div className={'long-text-format'}>{cocktailRecipe.notes}</div>*/}
+                    </div>
                   </>
                 )}
                 {props.showDescription && cocktailRecipe.description && (
                   <>
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Allgemeine Beschreibung</div>
-                    <div className={'long-text-format'}>{cocktailRecipe.description}</div>
+                    <div className={'pl-2'}>
+                      <ExpandableText text={cocktailRecipe.description} />
+                      {/*<div className={'long-text-format'}>{cocktailRecipe.description}</div>*/}
+                    </div>
                   </>
                 )}
                 {props.showHistory && cocktailRecipe.history && (
                   <>
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Geschichte und Entstehung</div>
-                    <div className={'long-text-format'}>{cocktailRecipe.history}</div>
+                    <div className={'pl-2'}>
+                      <ExpandableText text={cocktailRecipe.history} />
+                    </div>
+                    {/*<div className={'long-text-format'}>{cocktailRecipe.history}</div>*/}
                   </>
                 )}
 

--- a/components/cocktails/CocktailRecipeCardItem.tsx
+++ b/components/cocktails/CocktailRecipeCardItem.tsx
@@ -1,5 +1,5 @@
 import { CocktailRecipeFull } from '../../models/CocktailRecipeFull';
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { CompactCocktailRecipeInstruction } from './CompactCocktailRecipeInstruction';
 import { ShowCocktailInfoButton } from './ShowCocktailInfoButton';
 import { useRouter } from 'next/router';
@@ -9,10 +9,11 @@ import { fetchCocktail } from '../../lib/network/cocktails';
 import { CocktailRating } from '@prisma/client';
 import { fetchCocktailRatings } from '../../lib/network/cocktailRatings';
 import StatisticActions from '../StatisticActions';
-import ExpandableText from '../ExpandableText';
+import ExpandableText, { ExpandableTextHandle } from '../ExpandableText';
 
 export type CocktailRecipeOverviewItemRef = {
   refresh: () => void;
+  recalculateClamp: () => void;
 };
 
 export type CocktailRecipeOverviewItemProps = {
@@ -54,8 +55,19 @@ const CocktailRecipeCardItem = forwardRef<CocktailRecipeOverviewItemRef, Cocktai
     refresh();
   }, [refresh]);
 
+  const expandableRefs = useRef<Record<string, Record<string, ExpandableTextHandle | null>>>({});
+
+  const recalculateClamp = useCallback(() => {
+    Object.values(expandableRefs.current).forEach((textRefs) => Object.values(textRefs).forEach((expandableText) => expandableText?.recalculateClamp()));
+  }, []);
+
+  useEffect(() => {
+    recalculateClamp();
+  }, [recalculateClamp]);
+
   useImperativeHandle(ref, () => ({
     refresh,
+    recalculateClamp,
   }));
 
   const cocktailRecipe = typeof props.cocktailRecipe === 'string' ? loadedCocktailRecipe : props.cocktailRecipe;
@@ -92,7 +104,13 @@ const CocktailRecipeCardItem = forwardRef<CocktailRecipeOverviewItemRef, Cocktai
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Zubereitungsnotizen</div>
                     <div className={'pl-2'}>
-                      <ExpandableText text={cocktailRecipe.notes} />
+                      <ExpandableText
+                        text={cocktailRecipe.notes}
+                        ref={(el) => {
+                          if (!expandableRefs.current[cocktailRecipe.id]) expandableRefs.current[cocktailRecipe.id] = {};
+                          expandableRefs.current[cocktailRecipe.id]['notes'] = el;
+                        }}
+                      />
                       {/*<div className={'long-text-format'}>{cocktailRecipe.notes}</div>*/}
                     </div>
                   </>
@@ -102,7 +120,13 @@ const CocktailRecipeCardItem = forwardRef<CocktailRecipeOverviewItemRef, Cocktai
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Allgemeine Beschreibung</div>
                     <div className={'pl-2'}>
-                      <ExpandableText text={cocktailRecipe.description} />
+                      <ExpandableText
+                        text={cocktailRecipe.description}
+                        ref={(el) => {
+                          if (!expandableRefs.current[cocktailRecipe.id]) expandableRefs.current[cocktailRecipe.id] = {};
+                          expandableRefs.current[cocktailRecipe.id]['description'] = el;
+                        }}
+                      />
                       {/*<div className={'long-text-format'}>{cocktailRecipe.description}</div>*/}
                     </div>
                   </>
@@ -112,7 +136,13 @@ const CocktailRecipeCardItem = forwardRef<CocktailRecipeOverviewItemRef, Cocktai
                     <div className={'border-b border-base-100'}></div>
                     <div className={'font-bold'}>Geschichte und Entstehung</div>
                     <div className={'pl-2'}>
-                      <ExpandableText text={cocktailRecipe.history} />
+                      <ExpandableText
+                        text={cocktailRecipe.history}
+                        ref={(el) => {
+                          if (!expandableRefs.current[cocktailRecipe.id]) expandableRefs.current[cocktailRecipe.id] = {};
+                          expandableRefs.current[cocktailRecipe.id]['history'] = el;
+                        }}
+                      />
                     </div>
                     {/*<div className={'long-text-format'}>{cocktailRecipe.history}</div>*/}
                   </>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -315,6 +315,17 @@ export default function OverviewPage() {
     }
   }, []);
 
+  const triggerAllCocktailCardRefresh = useCallback(() => {
+    Object.keys(cocktailItemRefs.current).forEach((cocktailId) => {
+      if (cocktailItemRefs.current[cocktailId]) {
+        cocktailItemRefs.current[cocktailId]?.recalculateClamp();
+      }
+    });
+  }, []);
+  useEffect(() => {
+    triggerAllCocktailCardRefresh();
+  }, [lessItems]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Closing issues:

- Closes: #498 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

By having long notes, descriptions or history texts, the layout got destroyed pretty fast. To prevent this, i clamped the texts to a maximum of 3 lines and added a show more button. The buttons should only appear if the text is too long. When the layout changes (eye-> layout -> less cols toggle) the clamp gets recalculated.

## Affected sites (please check during review):

- [ ] Index - All cocktail Cards
- [ ] CocktailRecipe Form - there is also the Component used

