### PR TITLE
feat: Added cocktail amount adjustment in detail modal

### DIFF
--- a/components/StatisticActions.tsx
+++ b/components/StatisticActions.tsx
@@ -14,7 +14,8 @@ interface StatisticActionsProps {
   cardId?: string;
   actionSource: 'SEARCH_MODAL' | 'CARD' | 'DETAIL_MODAL' | 'QUEUE';
   notes?: string;
-
+  disabled?: { list?: boolean; listWithNote?: boolean; markAsDone?: boolean };
+  initData?: { comment?: string };
   onAddToQueue?: () => void;
   onMarkedAsDone?: () => void;
 }
@@ -24,7 +25,9 @@ export default function StatisticActions({
   cocktailId,
   cardId,
   actionSource,
+  disabled,
   notes,
+  initData,
   onMarkedAsDone,
   onAddToQueue,
   cocktailName,
@@ -45,7 +48,7 @@ export default function StatisticActions({
             setSubmitting: setSubmittingQueue,
           })
         }
-        disabled={submittingQueue}
+        disabled={submittingQueue || disabled?.list}
       >
         <MdPlaylistAdd />
         Liste
@@ -56,10 +59,16 @@ export default function StatisticActions({
         className={'btn btn-outline flex-1'}
         onClick={() =>
           modalContext.openModal(
-            <AddCocktailToQueueModal workspaceId={workspaceId} cocktailId={cocktailId} actionSource={actionSource} cocktailName={cocktailName} />,
+            <AddCocktailToQueueModal
+              workspaceId={workspaceId}
+              cocktailId={cocktailId}
+              actionSource={actionSource}
+              cocktailName={cocktailName}
+              initComment={initData?.comment}
+            />,
           )
         }
-        disabled={submittingQueue}
+        disabled={submittingQueue || disabled?.listWithNote}
       >
         <MdPlaylistAdd />
         mit Notiz
@@ -90,7 +99,7 @@ export default function StatisticActions({
             },
           })
         }
-        disabled={submittingStatistic}
+        disabled={submittingStatistic || disabled?.markAsDone}
       >
         <FaCheck />
         Gemacht

--- a/components/modals/AddCocktailToQueueModal.tsx
+++ b/components/modals/AddCocktailToQueueModal.tsx
@@ -8,13 +8,14 @@ interface AddCocktailToQueueModalProps {
   workspaceId: string;
   cocktailId: string;
   cocktailName: string;
+  initComment?: string;
   actionSource: 'SEARCH_MODAL' | 'CARD' | 'DETAIL_MODAL' | 'QUEUE';
 }
 
-export default function AddCocktailToQueueModal({ workspaceId, cocktailId, actionSource, cocktailName }: AddCocktailToQueueModalProps) {
+export default function AddCocktailToQueueModal({ workspaceId, cocktailId, actionSource, cocktailName, initComment }: AddCocktailToQueueModalProps) {
   const [submittingQueue, setSubmittingQueue] = useState(false);
 
-  const [notes, setNotes] = useState('');
+  const [notes, setNotes] = useState(initComment ?? '');
   const [amount, setAmount] = useState(1);
 
   const modalContext = useContext(ModalContext);

--- a/components/modals/CocktailDetailModal.tsx
+++ b/components/modals/CocktailDetailModal.tsx
@@ -259,6 +259,26 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
               <div className={'print:hidden'}>
                 <StatisticActions
                   workspaceId={router.query.workspaceId as string}
+                  disabled={{ list: amountAdjustment != 100 }}
+                  initData={{
+                    comment:
+                      amountAdjustment != 100
+                        ? `Angepasste Menge (${amountAdjustment}%):\n${loadedCocktail.steps
+                            .sort((a, b) => a.stepNumber - b.stepNumber)
+                            .map((step) => {
+                              return `${userContext.getTranslation(step.action.name, 'de')}${step.optional ? ' (optional)' : ''}\n${step.ingredients
+                                .sort((a, b) => a.ingredientNumber - b.ingredientNumber)
+                                .map((stepIngredient) => {
+                                  return `- ${((stepIngredient.amount ?? 0) * (amountAdjustment / 100))?.toLocaleString(undefined, {
+                                    minimumFractionDigits: 0,
+                                    maximumFractionDigits: 2,
+                                  })} ${userContext.getTranslation(stepIngredient.unit?.name ?? '', 'de')} ${stepIngredient.ingredient?.shortName ?? stepIngredient.ingredient?.name}${stepIngredient.optional ? '(optional)' : ''}`;
+                                })
+                                .join('\n')}`;
+                            })
+                            .join('\n')}`
+                        : undefined,
+                  }}
                   cocktailId={loadedCocktail.id}
                   cocktailName={loadedCocktail.name}
                   actionSource={'DETAIL_MODAL'}
@@ -276,6 +296,7 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
                   }
                 />
               </div>
+              {amountAdjustment != 100 && <div className={'font-thin'}>Die geänderte Menge fließt nicht in die Statistik mit ein</div>}
               <div className={'divider-sm'}></div>
               <details className="collapse collapse-arrow border">
                 <summary className="collapse-title font-bold">Menge Anpassen</summary>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -369,7 +369,7 @@ export default function OverviewPage() {
                             (seit {new Date(cocktailQueueItem.oldestTimestamp).toFormatTimeString()} Uhr)
                           </span>
                         </div>
-                        {cocktailQueueItem.notes && <span className={'italic lg:pb-1'}>Notiz: {cocktailQueueItem.notes}</span>}
+                        {cocktailQueueItem.notes && <span className={'long-text-format italic lg:pb-1'}>Notiz: {cocktailQueueItem.notes}</span>}
                         <div className={'flex w-full flex-row gap-2'}>
                           <div
                             className={'btn btn-square btn-outline btn-sm'}


### PR DESCRIPTION
## Closing issues:

- Closes: #515

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Its now possible to adjust the amount of the cocktail in percentage, changing the ingreident amounts. When changing the default amount, the "add to list with note" gets prefilled with the new amounts as comment.

## Affected sites (please check during review):

- [ ] Detail dialog of a cocktail
