### PR TITLE
fix: made cocktail queue grouping/ordering adjustable

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -371,18 +371,28 @@ export default function OverviewPage() {
                           };
                         })
                         .sortBy(['cocktailName', (item) => -(item.notes ?? '')]) // Sortiere nach cocktailName (asc) und notes (desc)
-                    : _(cocktailQueue).sortBy('timestamp')
-                  ) // Sortiere nach timestamp (desc)
+                    : _(cocktailQueue)
+                        .sortBy('timestamp') // Sortiere nach timestamp (desc)
+                        .map((item, key) => {
+                          return {
+                            cocktailId: item.cocktailId,
+                            notes: item.notes,
+                            cocktailName: item.cocktailName,
+                            count: 1,
+                            oldestTimestamp: item.timestamp,
+                          };
+                        })
+                  )
                     .value()
                     .map((cocktailQueueItem, index) => (
                       <div key={`cocktailQueue-item-${index}`} className={'flex w-full flex-row flex-wrap justify-between gap-2 pb-1 pt-1 lg:flex-col'}>
                         <div className={'flex flex-row flex-wrap items-center justify-between gap-1'}>
                           <div className={'font-bold'}>
-                            <strong>{cocktailQueueItem.count ?? 1}x</strong> {cocktailQueueItem.cocktailName}
+                            <strong>{cocktailQueueItem.count}x</strong> {cocktailQueueItem.cocktailName}
                           </div>
                           <span className={'flex flex-wrap gap-1'}>
                             {cocktailQueueItem.notes && <span className={'italic'}>mit Notiz</span>}
-                            (seit {new Date(cocktailQueueItem.oldestTimestamp ?? cocktailQueueItem.timestamp).toFormatTimeString()} Uhr)
+                            (seit {new Date(cocktailQueueItem?.oldestTimestamp).toFormatTimeString()} Uhr)
                           </span>
                         </div>
                         {cocktailQueueItem.notes && <span className={'long-text-format italic lg:pb-1'}>Notiz: {cocktailQueueItem.notes}</span>}

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -38,6 +38,7 @@ export default function OverviewPage() {
   const [showHistory, setShowHistory] = useState(false);
   const [showTime, setShowTime] = useState(false);
   const [showRating, setShowRating] = useState(false);
+  const [queueGrouping, setQueueGrouping] = useState<'ALPHABETIC' | 'NONE'>('NONE');
 
   const [cocktailCards, setCocktailCards] = useState<CocktailCardFull[]>([]);
   const [loadingCards, setLoadingCards] = useState(true);
@@ -183,6 +184,7 @@ export default function OverviewPage() {
     setShowHistory(userContext.user?.settings?.find((s) => s.setting == Setting.showHistory)?.value == 'true');
     setShowTime(userContext.user?.settings?.find((s) => s.setting == Setting.showTime)?.value == 'true');
     setShowRating(userContext.user?.settings?.find((s) => s.setting == Setting.showRating)?.value == 'true');
+    setQueueGrouping(userContext.user?.settings?.find((s) => s.setting == Setting.queueGrouping)?.value as 'ALPHABETIC' | 'NONE');
   }, [userContext.user?.settings]);
 
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -352,32 +354,35 @@ export default function OverviewPage() {
               }
             >
               <div className={`${showQueueAsOverlay ? 'bg-opacity-75 lg:max-w-60' : ''} flex w-full flex-col rounded-xl bg-base-300 p-2 print:hidden`}>
-                <div className={'underline'}>Warteschlange (A-Z)</div>
+                <div className={'underline'}>Warteschlange ({queueGrouping == 'NONE' ? 'Chronologisch' : 'A-Z'})</div>
                 <div className={'flex flex-col divide-y'}>
-                  {_(cocktailQueue)
-                    // .groupBy('cocktailId')
-                    .groupBy((item) => `${item.cocktailId}||${item.notes}`) // Gruppierung basierend auf cocktailId und notes
-                    .map((items, key) => {
-                      const [cocktailId, notes] = key.split('||'); // Extrahiere cocktailId und notes aus dem Key
-                      return {
-                        cocktailId,
-                        notes: notes === 'null' || notes === '' ? undefined : notes,
-                        cocktailName: items[0].cocktailName,
-                        count: items.length,
-                        oldestTimestamp: _.minBy(items, 'timestamp')!.timestamp, // Finde den ältesten Timestamp
-                      };
-                    })
-                    .sortBy(['cocktailName', (item) => -(item.notes ?? '')]) // Sortiere nach cocktailName (asc) und notes (desc)
+                  {(queueGrouping == 'ALPHABETIC'
+                    ? _(cocktailQueue)
+                        // .groupBy('cocktailId')
+                        .groupBy((item) => `${item.cocktailId}||${item.notes}`) // Gruppierung basierend auf cocktailId und notes
+                        .map((items, key) => {
+                          const [cocktailId, notes] = key.split('||'); // Extrahiere cocktailId und notes aus dem Key
+                          return {
+                            cocktailId,
+                            notes: notes === 'null' || notes === '' ? undefined : notes,
+                            cocktailName: items[0].cocktailName,
+                            count: items.length,
+                            oldestTimestamp: _.minBy(items, 'timestamp')!.timestamp, // Finde den ältesten Timestamp
+                          };
+                        })
+                        .sortBy(['cocktailName', (item) => -(item.notes ?? '')]) // Sortiere nach cocktailName (asc) und notes (desc)
+                    : _(cocktailQueue).sortBy('timestamp')
+                  ) // Sortiere nach timestamp (desc)
                     .value()
                     .map((cocktailQueueItem, index) => (
                       <div key={`cocktailQueue-item-${index}`} className={'flex w-full flex-row flex-wrap justify-between gap-2 pb-1 pt-1 lg:flex-col'}>
                         <div className={'flex flex-row flex-wrap items-center justify-between gap-1'}>
                           <div className={'font-bold'}>
-                            <strong>{cocktailQueueItem.count}x</strong> {cocktailQueueItem.cocktailName}
+                            <strong>{cocktailQueueItem.count ?? 1}x</strong> {cocktailQueueItem.cocktailName}
                           </div>
                           <span className={'flex flex-wrap gap-1'}>
                             {cocktailQueueItem.notes && <span className={'italic'}>mit Notiz</span>}
-                            (seit {new Date(cocktailQueueItem.oldestTimestamp).toFormatTimeString()} Uhr)
+                            (seit {new Date(cocktailQueueItem.oldestTimestamp ?? cocktailQueueItem.timestamp).toFormatTimeString()} Uhr)
                           </span>
                         </div>
                         {cocktailQueueItem.notes && <span className={'long-text-format italic lg:pb-1'}>Notiz: {cocktailQueueItem.notes}</span>}
@@ -733,6 +738,52 @@ export default function OverviewPage() {
                             }}
                           />
                         </label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className={'divider'}></div>
+
+                  <div className={`flex flex-col gap-2`}>
+                    <div className={'flex cursor-pointer flex-row items-center justify-between'} onClick={() => setShowRecipeOptions(!showRecipeOptions)}>
+                      <div className={'font-bold'}>Warteschlange</div>
+                      <div>{showRecipeOptions ? <FaAngleUp /> : <FaAngleDown />}</div>
+                    </div>
+                    <div className={`flex flex-col gap-2 ${showRecipeOptions ? '' : 'hidden'}`}>
+                      <div className="form-control">
+                        <div className={''}>Gruppierung</div>
+                        <div key={'grouping-alphabetic'} className="form-control">
+                          <label className="label">
+                            <div className={'label-text'}>Cocktailname (A-Z)</div>
+                            <input
+                              name={'card-radio'}
+                              type={'radio'}
+                              className={'radio'}
+                              value={'ALPHABETIC'}
+                              checked={queueGrouping == 'ALPHABETIC'}
+                              readOnly={true}
+                              onClick={() => {
+                                setQueueGrouping('ALPHABETIC');
+                                userContext.updateUserSetting(Setting.queueGrouping, 'ALPHABETIC');
+                              }}
+                            />
+                          </label>
+                          <label className="label">
+                            <div className={'label-text'}>Keine (Chronologisch)</div>
+                            <input
+                              name={'card-radio'}
+                              type={'radio'}
+                              className={'radio'}
+                              value={'NONE'}
+                              checked={queueGrouping == 'NONE'}
+                              readOnly={true}
+                              onClick={() => {
+                                setQueueGrouping('NONE');
+                                userContext.updateUserSetting(Setting.queueGrouping, 'NONE');
+                              }}
+                            />
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -239,6 +239,7 @@ export default function OverviewPage() {
   const [isDropdownScrollable, setIsDropdownScrollable] = useState(false);
 
   const [showRecipeOptions, setShowRecipeOptions] = useState(false);
+  const [showQueueOptions, setShowQueueOptions] = useState(false);
   const [showLayoutOptions, setShowLayoutOptions] = useState(false);
 
   const checkDropdownScroll = useCallback(() => {
@@ -354,7 +355,7 @@ export default function OverviewPage() {
               }
             >
               <div className={`${showQueueAsOverlay ? 'bg-opacity-75 lg:max-w-60' : ''} flex w-full flex-col rounded-xl bg-base-300 p-2 print:hidden`}>
-                <div className={'underline'}>Warteschlange ({queueGrouping == 'NONE' ? 'Chronologisch' : 'A-Z'})</div>
+                <div className={'underline'}>Warteschlange ({queueGrouping == 'ALPHABETIC' ? 'A-Z' : 'Chronologisch'})</div>
                 <div className={'flex flex-col divide-y'}>
                   {(queueGrouping == 'ALPHABETIC'
                     ? _(cocktailQueue)
@@ -368,6 +369,7 @@ export default function OverviewPage() {
                             cocktailName: items[0].cocktailName,
                             count: items.length,
                             oldestTimestamp: _.minBy(items, 'timestamp')!.timestamp, // Finde den ältesten Timestamp
+                            total: undefined,
                           };
                         })
                         .sortBy(['cocktailName', (item) => -(item.notes ?? '')]) // Sortiere nach cocktailName (asc) und notes (desc)
@@ -380,6 +382,7 @@ export default function OverviewPage() {
                             cocktailName: item.cocktailName,
                             count: 1,
                             oldestTimestamp: item.timestamp,
+                            total: cocktailQueue.filter((i) => i.cocktailId == item.cocktailId && i.notes == item.notes).length,
                           };
                         })
                   )
@@ -388,7 +391,12 @@ export default function OverviewPage() {
                       <div key={`cocktailQueue-item-${index}`} className={'flex w-full flex-row flex-wrap justify-between gap-2 pb-1 pt-1 lg:flex-col'}>
                         <div className={'flex flex-row flex-wrap items-center justify-between gap-1'}>
                           <div className={'font-bold'}>
-                            <strong>{cocktailQueueItem.count}x</strong> {cocktailQueueItem.cocktailName}
+                            <strong>{cocktailQueueItem.count}x</strong> {cocktailQueueItem.cocktailName}{' '}
+                            {cocktailQueueItem.total != undefined && cocktailQueueItem.total > 1 ? (
+                              <span className={'font-thin'}>(Insg. {cocktailQueueItem.total} gleiche)</span>
+                            ) : (
+                              <></>
+                            )}
                           </div>
                           <span className={'flex flex-wrap gap-1'}>
                             {cocktailQueueItem.notes && <span className={'italic'}>mit Notiz</span>}
@@ -755,11 +763,11 @@ export default function OverviewPage() {
                   <div className={'divider'}></div>
 
                   <div className={`flex flex-col gap-2`}>
-                    <div className={'flex cursor-pointer flex-row items-center justify-between'} onClick={() => setShowRecipeOptions(!showRecipeOptions)}>
+                    <div className={'flex cursor-pointer flex-row items-center justify-between'} onClick={() => setShowQueueOptions(!showQueueOptions)}>
                       <div className={'font-bold'}>Warteschlange</div>
-                      <div>{showRecipeOptions ? <FaAngleUp /> : <FaAngleDown />}</div>
+                      <div>{showQueueOptions ? <FaAngleUp /> : <FaAngleDown />}</div>
                     </div>
-                    <div className={`flex flex-col gap-2 ${showRecipeOptions ? '' : 'hidden'}`}>
+                    <div className={`flex flex-col gap-2 ${showQueueOptions ? '' : 'hidden'}`}>
                       <div className="form-control">
                         <div className={''}>Gruppierung</div>
                         <div key={'grouping-alphabetic'} className="form-control">
@@ -785,7 +793,7 @@ export default function OverviewPage() {
                               type={'radio'}
                               className={'radio'}
                               value={'NONE'}
-                              checked={queueGrouping == 'NONE'}
+                              checked={queueGrouping == 'NONE' || queueGrouping == undefined}
                               readOnly={true}
                               onClick={() => {
                                 setQueueGrouping('NONE');

--- a/prisma/migrations/20250131114341_queue_ordering/migration.sql
+++ b/prisma/migrations/20250131114341_queue_ordering/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Setting" ADD VALUE 'queueGrouping';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ enum Setting {
   showDescription
   showTime
   showRating
+  queueGrouping
 }
 
 enum WorkspaceSettingKey {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,7 @@ model User {
   settings              UserSetting[]
   CocktailCalculation   CocktailCalculation[]
   CocktailStatisticItem CocktailStatisticItem[]
-  WorkspaceJoinRequest WorkspaceJoinRequest[]
+  WorkspaceJoinRequest  WorkspaceJoinRequest[]
 }
 
 enum Setting {
@@ -111,7 +111,7 @@ model WorkspaceJoinCode {
 
   expires     DateTime?
   onlyUseOnce Boolean   @default(false)
-  used Int @default(0)
+  used        Int       @default(0)
 
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
@@ -190,8 +190,8 @@ model Workspace {
   IngredientVolume                  IngredientVolume[]
   CocktailQueue                     CocktailQueue[]
   Ice                               Ice[]
-  WorkspaceJoinCode    WorkspaceJoinCode[]
-  WorkspaceJoinRequest WorkspaceJoinRequest[]
+  WorkspaceJoinCode                 WorkspaceJoinCode[]
+  WorkspaceJoinRequest              WorkspaceJoinRequest[]
 }
 
 model Signage {
@@ -508,7 +508,7 @@ model CocktailQueue {
   cocktail    CocktailRecipe @relation(fields: [cocktailId], references: [id], onDelete: Cascade)
   workspaceId String
   workspace   Workspace      @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  notes String?
+  notes       String?
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @default(now()) @updatedAt
 }


### PR DESCRIPTION
## Closing issues:

- Closes: #533 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I´e created all necessary migrations?
- [ ] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [ ] No build errors (`pnpm build`)
- [ ] I´ve tested the implemented function by my own
- [ ] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

Cocktail page -> Eye -> Queue Settings -> Grouping of the queue is now adjustable

## Affected sites (please check during review):

- [ ] Cocktail page