### PR TITLE
fix: Improved the "view cocktail" from the queue behavior 

### DIFF
--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -19,6 +19,7 @@ import '../../../lib/DateUtils';
 import { addCocktailToStatistic, removeCocktailFromQueue } from '../../../lib/network/cocktailTracking';
 import { CocktailDetailModal } from '../../../components/modals/CocktailDetailModal';
 import _ from 'lodash';
+import { CocktailRecipeFull } from '../../../models/CocktailRecipeFull';
 
 export default function OverviewPage() {
   const modalContext = useContext(ModalContext);
@@ -43,6 +44,8 @@ export default function OverviewPage() {
   const [cocktailCards, setCocktailCards] = useState<CocktailCardFull[]>([]);
   const [loadingCards, setLoadingCards] = useState(true);
   const [loadingGroups, setLoadingGroups] = useState(false);
+
+  const [selectedCocktail, setSelectedCocktail] = useState<CocktailRecipeFull | string | undefined>(undefined);
 
   // Search modal shortcut (Shift + F)
   useEffect(() => {
@@ -490,6 +493,8 @@ export default function OverviewPage() {
                 showRating={showRating}
                 showNotes={showNotes}
                 showDescription={showDescription}
+                selectedCocktail={selectedCocktail}
+                setSelectedCocktail={setSelectedCocktail}
               />
             ) : loadingGroups ? (
               <PageCenter>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -391,20 +391,39 @@ export default function OverviewPage() {
                   )
                     .value()
                     .map((cocktailQueueItem, index) => (
-                      <div key={`cocktailQueue-item-${index}`} className={'flex w-full flex-row flex-wrap justify-between gap-2 pb-1 pt-1 lg:flex-col'}>
-                        <div className={'flex flex-row flex-wrap items-center justify-between gap-1'}>
+                      <div
+                        key={`cocktailQueue-item-${index}`}
+                        className={'flex w-full cursor-pointer flex-row flex-wrap justify-between gap-2 pb-1 pt-1 lg:flex-col'}
+                        onClick={() => {
+                          if (selectedCardId == 'search' || selectedCardId == undefined) {
+                            setSelectedCocktail(cocktailQueueItem.cocktailId);
+                          } else {
+                            modalContext.openModal(
+                              <CocktailDetailModal
+                                cocktailId={cocktailQueueItem.cocktailId}
+                                onRefreshRatings={() => handleCocktailCardRefresh(cocktailQueueItem.cocktailName)}
+                                queueNotes={cocktailQueueItem.notes}
+                                queueAmount={cocktailQueueItem.count}
+                                openReferer={'QUEUE'}
+                              />,
+                              true,
+                            );
+                          }
+                        }}
+                      >
+                        <div className={'mt-1 flex flex-row flex-wrap items-center justify-between gap-1'}>
                           <div className={'font-bold'}>
                             <strong>{cocktailQueueItem.count}x</strong> {cocktailQueueItem.cocktailName}{' '}
-                            {cocktailQueueItem.total != undefined && cocktailQueueItem.total > 1 ? (
-                              <span className={'font-thin'}>(Insg. {cocktailQueueItem.total} gleiche)</span>
-                            ) : (
-                              <></>
-                            )}
                           </div>
-                          <span className={'flex flex-wrap gap-1'}>
-                            {cocktailQueueItem.notes && <span className={'italic'}>mit Notiz</span>}
-                            (seit {new Date(cocktailQueueItem?.oldestTimestamp).toFormatTimeString()} Uhr)
-                          </span>
+                          <span className={'flex flex-wrap gap-1'}>{cocktailQueueItem.notes && <span className={'italic'}>mit Notiz</span>}</span>
+                        </div>
+                        <div className={'flex flex-row flex-wrap items-center justify-between gap-1'}>
+                          {cocktailQueueItem.total != undefined && cocktailQueueItem.total > 1 ? (
+                            <span className={'font-thin'}>(Insg. {cocktailQueueItem.total} gleiche)</span>
+                          ) : (
+                            <span></span>
+                          )}
+                          <span>(seit {new Date(cocktailQueueItem?.oldestTimestamp).toFormatTimeString()} Uhr)</span>
                         </div>
                         {cocktailQueueItem.notes && <span className={'long-text-format italic lg:pb-1'}>Notiz: {cocktailQueueItem.notes}</span>}
                         <div className={'flex w-full flex-row gap-2'}>

--- a/pages/workspaces/[workspaceId]/search.tsx
+++ b/pages/workspaces/[workspaceId]/search.tsx
@@ -11,23 +11,23 @@ interface SearchPageProps {
   showRating: boolean;
   showDescription: boolean;
   showNotes: boolean;
+  selectedCocktail: CocktailRecipeFull | string | undefined;
+  setSelectedCocktail: (cocktail: CocktailRecipeFull) => void;
 }
 
 export default function SearchPage(props: SearchPageProps) {
-  const [selectedCocktail, setSelectedCocktail] = useState<CocktailRecipeFull | undefined>(undefined);
-
   const router = useRouter();
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [selectedCocktail]);
+  }, [props.selectedCocktail]);
 
   return (
     <div className={'flex flex-col-reverse gap-2 md:flex-row'}>
       <div className={'card w-full flex-1'}>
         <div className={'card-body'}>
           <SearchModal
-            onCocktailSelectedObject={(cocktail) => setSelectedCocktail(cocktail)}
+            onCocktailSelectedObject={(cocktail) => props.setSelectedCocktail(cocktail)}
             selectionLabel={'Ansehen'}
             showRecipe={false}
             customWidthClassName={'w-full'}
@@ -35,9 +35,9 @@ export default function SearchPage(props: SearchPageProps) {
         </div>
       </div>
       <div className={'h-min w-full flex-1'}>
-        {selectedCocktail ? (
+        {props.selectedCocktail ? (
           <CocktailRecipeCardItem
-            cocktailRecipe={selectedCocktail}
+            cocktailRecipe={props.selectedCocktail}
             showImage={props.showImage}
             showInfo={true}
             showPrice={true}


### PR DESCRIPTION
## Closing issues:

None

## Before you mark this PR as ready, please check the following points

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

A design change that you may or may not like:

To make the interface friendlier for touch devices, I increased the size of the queue items (Date and hint about multiple occurrences on an extra line) and bound a click event on the complete queue item, that shows the cocktail details.
When on the search page, the click action instead shows the cocktail details as the cocktail would have been selected via the search.

[Video](https://i.imgur.com/CWlbyOC.mp4)

## Affected sites (please check during review):

- [x] Bartenders/Search View

## Further comments

Nice project!

