### PR TITLE
fix: improve behaviour on mobile/tablet devices

### DIFF
--- a/components/StatisticActions.tsx
+++ b/components/StatisticActions.tsx
@@ -94,6 +94,7 @@ export default function StatisticActions({
                   actionSource={actionSource}
                   cocktailName={cocktailName}
                   options={options}
+                  onMarkedAsDone={onMarkedAsDone}
                 />,
               );
             },

--- a/components/layout/AlertBoundary/AlertsContainer.tsx
+++ b/components/layout/AlertBoundary/AlertsContainer.tsx
@@ -15,7 +15,7 @@ interface AlertsContainerProps {
   fade?: boolean;
 }
 
-const duration = 5000;
+const duration = 3000;
 
 function AlertsContainer({ id = 'default-alert', fade }: AlertsContainerProps) {
   const mounted = useRef(false);

--- a/components/layout/AlertBoundary/index.tsx
+++ b/components/layout/AlertBoundary/index.tsx
@@ -22,7 +22,7 @@ export function AlertBoundary(props: AlertBoundaryProps) {
           <></>
         )}
       </>
-      <div className="fixed left-2 top-2 z-50 ml-2 flex flex-col items-center justify-center overflow-hidden md:left-10 md:top-10 print:hidden">
+      <div className="fixed bottom-2 left-2 right-2 z-50 ml-2 flex flex-col items-center justify-center overflow-hidden print:hidden">
         <AlertsContainer />
       </div>
       {props.children}

--- a/components/modals/SearchModal.tsx
+++ b/components/modals/SearchModal.tsx
@@ -112,7 +112,7 @@ export function SearchModal(props: SearchModalProps) {
             showRating={true}
             showStatisticActions={false}
             showPrice={true}
-            showInfo={true}
+            showDetailsOnClick={true}
           />
 
           {props.onCocktailSelectedObject != undefined ? (

--- a/components/modals/SelectSpecifyCocktailForStatisticModal.tsx
+++ b/components/modals/SelectSpecifyCocktailForStatisticModal.tsx
@@ -9,6 +9,7 @@ interface SelectSpecifyCocktailForStatisticModalProps {
   cardId?: string;
   cocktailName: string;
   actionSource: 'SEARCH_MODAL' | 'CARD' | 'DETAIL_MODAL' | 'QUEUE';
+  onMarkedAsDone?: () => void;
   options: { _min: { id: string }; notes: string }[];
 }
 
@@ -19,6 +20,7 @@ export default function SelectSpecifyCocktailForStatisticModal({
   cocktailName,
   options,
   actionSource,
+  onMarkedAsDone,
 }: SelectSpecifyCocktailForStatisticModalProps) {
   const modalContext = useContext(ModalContext);
   const [submittingStatistic, setSubmittingStatistic] = React.useState<{ [key: string]: boolean }>({});
@@ -53,7 +55,10 @@ export default function SelectSpecifyCocktailForStatisticModal({
                   setSubmitting: () => {
                     setSubmittingStatistic({ [`option-${option._min.id}`]: true });
                   },
-                  onSuccess: () => modalContext.closeModal(),
+                  onSuccess: () => {
+                    modalContext.closeModal();
+                    onMarkedAsDone?.();
+                  },
                 });
               }}
             >
@@ -79,7 +84,10 @@ export default function SelectSpecifyCocktailForStatisticModal({
                 setSubmitting: () => {
                   setSubmittingStatistic({ normal: true });
                 },
-                onSuccess: () => modalContext.closeModal(),
+                onSuccess: () => {
+                  modalContext.closeModal();
+                  onMarkedAsDone?.();
+                },
               });
             }}
           >

--- a/pages/api/workspaces/[workspaceId]/statistics/cocktails/add.ts
+++ b/pages/api/workspaces/[workspaceId]/statistics/cocktails/add.ts
@@ -92,7 +92,15 @@ export default withHttpMethods({
             },
           });
 
-          return res.status(400).json({ message: StatisticBadRequestMessage, data: oldestEntries });
+          // Check if there are any cocktails with notes
+          const notesEntry = oldestEntries.find((entry) => entry.notes != null);
+
+          if (notesEntry == null && oldestEntries.length > 0 && oldestEntries[0]._min?.id != null) {
+            // Delete the oldest entry without notes
+            await prisma.cocktailQueue.delete({ where: { id: oldestEntries[0]._min.id } });
+          } else {
+            return res.status(400).json({ message: StatisticBadRequestMessage, data: oldestEntries });
+          }
         }
       }
     }

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -316,7 +316,7 @@ export default function OverviewPage() {
       const maxHeight = windowSize.height - (windowSize.height - rect.y) - (process.env.NODE_ENV == 'development' ? 40 : 0) - 8;
       setMaxDropdownHeight(maxHeight);
     }
-  }, [windowSize]);
+  }, [windowSize, showSettingsAtBottom]);
 
   const timeComponent = (
     <div className={'w-full text-center'}>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -704,7 +704,7 @@ export default function OverviewPage() {
                                     }}
                                     showImage={showImage}
                                     showTags={showTags}
-                                    showInfo={true}
+                                    showDetailsOnClick={true}
                                     showPrice={groupItem.specialPrice == undefined && group.groupPrice == undefined}
                                     specialPrice={groupItem.specialPrice ?? group.groupPrice ?? undefined}
                                     cocktailRecipe={groupItem.cocktailId}

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -43,6 +43,7 @@ export default function OverviewPage() {
   const [showRating, setShowRating] = useState(false);
   const [queueGrouping, setQueueGrouping] = useState<'ALPHABETIC' | 'NONE'>('NONE');
   const [showFastQueueCheck, setShowFastQueueCheck] = useState(false);
+  const [showSettingsAtBottom, setShowSettingsAtBottom] = useState(false);
 
   const [cocktailCards, setCocktailCards] = useState<CocktailCardFull[]>([]);
   const [loadingCards, setLoadingCards] = useState(true);
@@ -192,6 +193,7 @@ export default function OverviewPage() {
     setShowRating(userContext.user?.settings?.find((s) => s.setting == Setting.showRating)?.value == 'true');
     setQueueGrouping(userContext.user?.settings?.find((s) => s.setting == Setting.queueGrouping)?.value as 'ALPHABETIC' | 'NONE');
     setShowFastQueueCheck(userContext.user?.settings?.find((s) => s.setting == Setting.showFastQueueCheck)?.value == 'true');
+    setShowSettingsAtBottom(userContext.user?.settings?.find((s) => s.setting == Setting.showSettingsAtBottom)?.value == 'true');
   }, [userContext.user?.settings]);
 
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -732,8 +734,13 @@ export default function OverviewPage() {
 
         {showTime ? <div className={'pb-2'}>{timeComponent}</div> : <></>}
 
-        <div ref={actionButtonRef} className={'fixed bottom-2 right-2 z-10 flex flex-col space-y-2 md:bottom-5 md:right-5 print:hidden'}>
-          <div className="dropdown dropdown-end dropdown-top pt-2">
+        <div
+          ref={actionButtonRef}
+          className={
+            'bottom-2 right-2 z-10 flex space-y-2 md:bottom-5 md:right-5 print:hidden' + (showSettingsAtBottom ? ' mx-2 justify-end' : ' fixed flex-col')
+          }
+        >
+          <div className={'dropdown dropdown-end dropdown-top pt-2' + (showSettingsAtBottom ? ' mr-1' : '')}>
             <label tabIndex={0} className={'btn btn-square btn-primary rounded-xl md:btn-lg'}>
               <FaEye />
             </label>
@@ -1042,6 +1049,20 @@ export default function OverviewPage() {
                           />
                         </label>
                       </div>
+                      <div className="form-control">
+                        <label className="label">
+                          Einstellungen am Ende
+                          <input
+                            type={'checkbox'}
+                            className={'toggle toggle-primary'}
+                            checked={showSettingsAtBottom}
+                            readOnly={true}
+                            onClick={() => {
+                              userContext.updateUserSetting(Setting.showSettingsAtBottom, !showSettingsAtBottom ? 'true' : 'false');
+                            }}
+                          />
+                        </label>
+                      </div>
                     </div>
                   </div>
                   <div className={'divider'}></div>
@@ -1058,7 +1079,7 @@ export default function OverviewPage() {
 
           <>
             {selectedCardId != 'search' && selectedCardId != undefined ? (
-              <div className={'tooltip'} data-tip={'Suche (Shift + F)'}>
+              <div className={'tooltip' + (showSettingsAtBottom ? ' mr-1' : '')} data-tip={'Suche (Shift + F)'}>
                 <div
                   className={'btn btn-square btn-primary rounded-xl md:btn-lg'}
                   onClick={() => modalContext.openModal(<SearchModal showStatisticActions={showStatisticActions} />)}

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -541,14 +541,14 @@ export default function OverviewPage() {
         {showTime ? <div className={'pt-2'}>{timeComponent}</div> : <></>}
 
         <div
-          className={`grid grid-cols-1 gap-2 p-2 ${showQueueAsOverlay ? '' : showStatisticActions && cocktailQueue.length > 0 ? 'lg:grid-cols-6' : ''} print:grid-cols-5 print:overflow-clip print:p-0`}
+          className={`grid grid-cols-1 gap-2 p-2 ${showQueueAsOverlay ? '' : showStatisticActions && cocktailQueue.length > 0 ? 'lg:grid-cols-8 xl:grid-cols-6' : ''} print:grid-cols-5 print:overflow-clip print:p-0`}
         >
           {showStatisticActions && cocktailQueue.length > 0 ? (
             <div
               className={
                 showQueueAsOverlay
                   ? `sticky right-0 z-10 col-span-5 flex w-full justify-end print:hidden ${process.env.NODE_ENV == 'development' ? 'md:top-12' : 'md:top-2'}`
-                  : 'order-first col-span-5 w-full lg:order-last lg:col-span-1 print:hidden'
+                  : 'order-first col-span-5 w-full lg:order-last lg:col-span-2 xl:col-span-1 print:hidden'
               }
             >
               <div className={`${showQueueAsOverlay ? 'bg-opacity-75 lg:max-w-60' : ''} flex w-full flex-col rounded-xl bg-base-300 p-2 print:hidden`}>
@@ -652,7 +652,7 @@ export default function OverviewPage() {
             <></>
           )}
 
-          <div className={`order-1 col-span-5 flex w-full flex-col space-y-2 overflow-y-auto rounded-xl`}>
+          <div className={`order-1 col-span-5 flex w-full flex-col space-y-2 overflow-y-auto rounded-xl lg:col-span-6 xl:col-span-5`}>
             {selectedCardId == 'search' || selectedCardId == undefined ? (
               <SearchPage
                 showImage={showImage}

--- a/pages/workspaces/[workspaceId]/search.tsx
+++ b/pages/workspaces/[workspaceId]/search.tsx
@@ -39,7 +39,7 @@ export default function SearchPage(props: SearchPageProps) {
           <CocktailRecipeCardItem
             cocktailRecipe={props.selectedCocktail}
             showImage={props.showImage}
-            showInfo={true}
+            showDetailsOnClick={true}
             showPrice={true}
             showDescription={props.showDescription}
             showNotes={props.showNotes}

--- a/prisma/migrations/20250309093018_show_settings_at_bottom/migration.sql
+++ b/prisma/migrations/20250309093018_show_settings_at_bottom/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Setting" ADD VALUE 'showSettingsAtBottom';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ enum Setting {
   showRating
   queueGrouping
   showFastQueueCheck
+  showSettingsAtBottom
 }
 
 enum WorkspaceSettingKey {


### PR DESCRIPTION
## Before you mark this PR as ready, please check the following points

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

This PR makes some small adjustments to improve the experience on small tablet devices (around 9"):

- Add new settings option to show the settings buttons on the bottom of the page instead of letting them float
- Open the cocktail details dialog when clicking on the name/recipe instead of the small info button
  - If you do not like this change, this could be made optional
- Increase width of queue-view on lg-sized displays
- Show alerts on the bottom left to not block relevant information, only show alerts for 3 seconds
- Directly mark cocktail as done if there are not cocktails with notes in the queue
  - Close cocktail detail dialog after all cocktails of a type has been marked as done.

## Affected sites (please check during review):

- [x] Bartenders view

## Further comments

A release after merging would be appreciated.
