### PR TITLE
feat: Default crop image and add unit when importing an ingredient from a website

### DIFF
--- a/components/ingredients/IngredientForm.tsx
+++ b/components/ingredients/IngredientForm.tsx
@@ -262,11 +262,19 @@ export function IngredientForm(props: IngredientFormProps) {
                             await setFieldValue('image', undefined);
                             await setFieldValue('originalImage', convertBase64ToFile(data.image));
                           }
-                          if (data.volume != 0) {
-                            await setFieldValue('volume', data.volume);
-                          }
-                          await setFieldValue('selectedUnit', allUnits.find((unit) => unit.name == 'CL')?.id ?? '');
+                          const selectedUnitId = allUnits.find((unit) => unit.name == 'CL')?.id ?? '';
                           checkSimilarName(data.name);
+
+                          if (data.volume != 0 && selectedUnitId != '') {
+                            await setFieldValue('units', [{ unitId: selectedUnitId, volume: data.volume }]);
+                          } else {
+                            if (data.volume != 0) {
+                              await setFieldValue('volume', data.volume);
+                            }
+                            await setFieldValue('selectedUnit', selectedUnitId);
+                          }
+
+                          alertService.info('Daten geladen, bitte überprüfen!');
                         });
                       } else {
                         alertService.warn('Es konnten keine Daten über die URL geladen werden.');


### PR DESCRIPTION
## Closing issues:

- Closes: #580

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

- As described in the issue, i added the ingredient volume automaticaly (cl preffered, otherwise, the first unit)
- I changed the crop to have a default crop selection with max size

## Affected sites (please check during review):

- [x] CocktailRecipeForm (image)
- [x] Create/Update Ingredient (image, import)

## Further comments

@ibot3 as you mentioned it would be nice to have the image cropped by default. I didn´t get it to work with the refs so far, so i hope the default crop selection will improve the ux at least a bit. After my thesis end in June i have more time to have look on it.