### PR TITLE
fix: Prices always are shown with 2 decimal places (except the CocktailDetail dialog, on zero as decimal place)

### DIFF
--- a/components/cocktails/CocktailRecipeForm.tsx
+++ b/components/cocktails/CocktailRecipeForm.tsx
@@ -36,6 +36,7 @@ import CropComponent from '../CropComponent';
 import { FaCropSimple } from 'react-icons/fa6';
 import DeepDiff from 'deep-diff';
 import { RoutingContext } from '@lib/context/RoutingContextProvider';
+import '../../lib/NumberUtils';
 
 interface CocktailRecipeFormProps {
   cocktailRecipe?: CocktailRecipeFullWithImage;
@@ -893,10 +894,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                           (ingredients
                                             .find((ingredient) => ingredient.id == stepIngredient.ingredientId)
                                             ?.IngredientVolume.find((volumeUnits) => volumeUnits.unitId == stepIngredient.unitId)?.volume ?? 1)
-                                        ).toLocaleString(undefined, {
-                                          minimumFractionDigits: 2,
-                                          maximumFractionDigits: 2,
-                                        })}{' '}
+                                        ).formatPrice()}{' '}
                                         €/{userContext.getTranslation(stepIngredient?.unit?.name ?? '', 'de')}
                                       </div>
                                       <div className={'text-end'}>
@@ -907,10 +905,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                                               .find((ingredient) => ingredient.id == stepIngredient.ingredientId)
                                               ?.IngredientVolume.find((volumeUnits) => volumeUnits.unitId == stepIngredient.unitId)?.volume ?? 1)) *
                                           (stepIngredient.amount ?? 0)
-                                        ).toLocaleString(undefined, {
-                                          minimumFractionDigits: 2,
-                                          maximumFractionDigits: 2,
-                                        })}
+                                        ).formatPrice()}
                                         €
                                       </div>
                                     </>
@@ -938,20 +933,10 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                         <>
                           <div key={`price-calculation-step-garnish-name`}>{garnish?.garnish?.name}</div>
                           <div key={`price-calculation-step-garnish-price`} className={'grid grid-cols-2'}>
-                            <div>
-                              1 x{' '}
-                              {(garnish?.garnish?.price ?? 0).toLocaleString(undefined, {
-                                minimumFractionDigits: 2,
-                                maximumFractionDigits: 2,
-                              })}
-                            </div>
+                            <div>1 x {(garnish?.garnish?.price ?? 0).formatPrice()}</div>
                             <div className={'text-end'}>
                               {(values.steps as CocktailRecipeStepFull[]).some((step) => step.ingredients.length > 0) ? '+ ' : ''}
-                              {(garnish?.garnish?.price ?? 0).toLocaleString(undefined, {
-                                minimumFractionDigits: 2,
-                                maximumFractionDigits: 2,
-                              })}
-                              €
+                              {(garnish?.garnish?.price ?? 0).formatPrice()}€
                             </div>
                           </div>
                         </>
@@ -962,12 +947,7 @@ export function CocktailRecipeForm(props: CocktailRecipeFormProps) {
                     <div className={'grid grid-cols-3'}>
                       <div></div>
                       <div></div>
-                      <div className={'text-end font-bold'}>
-                        {calcCocktailTotalPrice(values, ingredients).toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        }) + ' €'}
-                      </div>
+                      <div className={'text-end font-bold'}>{calcCocktailTotalPrice(values, ingredients).formatPrice() + ' €'}</div>
                     </div>
                   </div>
                 </div>

--- a/components/cocktails/CompactCocktailRecipeInstruction.tsx
+++ b/components/cocktails/CompactCocktailRecipeInstruction.tsx
@@ -7,6 +7,7 @@ import ImageModal from '../modals/ImageModal';
 import { Loading } from '../Loading';
 import StarsComponent from '../StarsComponent';
 import { CocktailRating } from '@generated/prisma/client';
+import '../../lib/NumberUtils';
 
 interface CompactCocktailRecipeInstructionProps {
   cocktailRecipe: CocktailRecipeFull;
@@ -30,14 +31,7 @@ export function CompactCocktailRecipeInstruction(props: CompactCocktailRecipeIns
       {props.showPrice == true ? (
         <div className={'col-span-1 text-right text-xl font-bold'}>
           {(props.specialPrice ?? props.cocktailRecipe.price) != undefined
-            ? (props.specialPrice?.toLocaleString(undefined, {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 2,
-              }) ??
-              props.cocktailRecipe.price?.toLocaleString(undefined, {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 2,
-              }) + ' €')
+            ? (props.specialPrice?.formatPriceEfficent() ?? props.cocktailRecipe.price?.formatPriceEfficent() + ' €')
             : ''}
         </div>
       ) : (

--- a/components/modals/CocktailDetailModal.tsx
+++ b/components/modals/CocktailDetailModal.tsx
@@ -84,11 +84,6 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
                     {loadedCocktail.price.formatPriceEfficent() + ' €'}
                     {amountAdjustment != 100
                       ? ` ${(loadedCocktail.price * (amountAdjustment / 100) - loadedCocktail.price)
-                          // .toLocaleString(undefined, {
-                          //   signDisplay: 'exceptZero',
-                          //   minimumFractionDigits: 0,
-                          //   maximumFractionDigits: 2,
-                          // })
                           .formatPriceEfficent({ signDisplay: 'exceptZero' })
                           .replace('-', '- ')
                           .replace('+', '+ ')} € = ${(
@@ -279,24 +274,14 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
                                 .join('\n')}`;
                             })
                             .join('\n')}\nBasispreis ± angepasste Menge = Verkaufspreis (${amountAdjustment}%):\n${
-                            loadedCocktail.price?.toLocaleString(undefined, {
-                              minimumFractionDigits: 0,
-                              maximumFractionDigits: 2,
-                            }) + ' €'
+                            loadedCocktail.price?.formatPriceEfficent() + ' €'
                           } ${((loadedCocktail.price ?? 0) * (amountAdjustment / 100) - (loadedCocktail.price ?? 0))
-                            .toLocaleString(undefined, {
-                              signDisplay: 'exceptZero',
-                              minimumFractionDigits: 0,
-                              maximumFractionDigits: 2,
-                            })
+                            .formatPriceEfficent({ signDisplay: 'exceptZero' })
                             .replace('-', '- ')
                             .replace('+', '+ ')} € = ${(
                             (loadedCocktail.price ?? 0) +
                             ((loadedCocktail.price ?? 0) * (amountAdjustment / 100) - (loadedCocktail!.price ?? 0))
-                          ).toLocaleString(undefined, {
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          })} €`
+                          ).formatPriceEfficent()} €`
                         : undefined,
                   }}
                   cocktailId={loadedCocktail.id}
@@ -532,28 +517,18 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
                 <>
                   <div className={'font-bold'}>Materialkosten</div>
                   <div>
-                    {calcCocktailTotalPrice(loadedCocktail, ingredients).toLocaleString(undefined, {
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 2,
-                    }) + ' €'}
+                    {calcCocktailTotalPrice(loadedCocktail, ingredients).formatPrice() + ' €'}
                     {amountAdjustment != 100
                       ? ` ${(
                           calcCocktailTotalPrice(loadedCocktail, ingredients) * (amountAdjustment / 100) -
                           calcCocktailTotalPrice(loadedCocktail, ingredients)
                         )
-                          .toLocaleString(undefined, {
-                            signDisplay: 'exceptZero',
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          })
+                          .formatPrice({ signDisplay: 'exceptZero' })
                           .replace('-', '- ')
                           .replace('+', '+ ')} € = ${(
                           calcCocktailTotalPrice(loadedCocktail, ingredients) +
                           (calcCocktailTotalPrice(loadedCocktail, ingredients) * (amountAdjustment / 100) - calcCocktailTotalPrice(loadedCocktail, ingredients))
-                        ).toLocaleString(undefined, {
-                          minimumFractionDigits: 0,
-                          maximumFractionDigits: 2,
-                        })} € (${amountAdjustment}%)`
+                        ).formatPrice()} € (${amountAdjustment}%)`
                       : ''}
                   </div>
                 </>

--- a/components/modals/CocktailDetailModal.tsx
+++ b/components/modals/CocktailDetailModal.tsx
@@ -21,6 +21,7 @@ import { fetchCocktail } from '@lib/network/cocktails';
 import StatisticActions from '../StatisticActions';
 import { toInteger } from 'lodash';
 import { FaArrowRotateLeft } from 'react-icons/fa6';
+import '../../lib/NumberUtils';
 
 interface CocktailDetailModalProps {
   cocktailId: string;
@@ -80,25 +81,20 @@ export function CocktailDetailModal(props: CocktailDetailModalProps) {
                 <>
                   {' - '}
                   <span className={'font-bold'}>
-                    {loadedCocktail.price.toLocaleString(undefined, {
-                      minimumFractionDigits: 0,
-                      maximumFractionDigits: 2,
-                    }) + ' €'}
+                    {loadedCocktail.price.formatPriceEfficent() + ' €'}
                     {amountAdjustment != 100
                       ? ` ${(loadedCocktail.price * (amountAdjustment / 100) - loadedCocktail.price)
-                          .toLocaleString(undefined, {
-                            signDisplay: 'exceptZero',
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          })
+                          // .toLocaleString(undefined, {
+                          //   signDisplay: 'exceptZero',
+                          //   minimumFractionDigits: 0,
+                          //   maximumFractionDigits: 2,
+                          // })
+                          .formatPriceEfficent({ signDisplay: 'exceptZero' })
                           .replace('-', '- ')
                           .replace('+', '+ ')} € = ${(
                           loadedCocktail.price +
                           (loadedCocktail.price * (amountAdjustment / 100) - loadedCocktail.price)
-                        ).toLocaleString(undefined, {
-                          minimumFractionDigits: 0,
-                          maximumFractionDigits: 2,
-                        })} €`
+                        ).formatPriceEfficent()} €`
                       : ''}
                   </span>
                 </>

--- a/lib/NumberUtils.ts
+++ b/lib/NumberUtils.ts
@@ -1,0 +1,28 @@
+import 'react';
+
+interface FormatProps {
+  signDisplay?: 'always' | 'auto' | 'exceptZero' | 'negative' | 'never';
+}
+
+declare global {
+  interface Number {
+    formatPriceEfficent(props?: FormatProps): String;
+    formatPrice(props?: FormatProps): String;
+  }
+}
+
+Number.prototype.formatPriceEfficent = function (props: FormatProps) {
+  return (Math.round(this.valueOf() * 10 ** 2) / 10 ** 2).toLocaleString(undefined, {
+    signDisplay: props?.signDisplay,
+    minimumFractionDigits: this.valueOf() % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+Number.prototype.formatPrice = function (props: FormatProps): String {
+  return this.toLocaleString(undefined, {
+    signDisplay: props?.signDisplay,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};

--- a/pages/workspaces/[workspaceId]/manage/calculations/[id].tsx
+++ b/pages/workspaces/[workspaceId]/manage/calculations/[id].tsx
@@ -19,6 +19,7 @@ import _ from 'lodash';
 import { fetchUnits } from '@lib/network/units';
 import '../../../../../lib/DateUtils';
 import { RoutingContext } from '@lib/context/RoutingContextProvider';
+import '../../../../../lib/NumberUtils';
 
 interface CocktailCalculationItem {
   cocktail: CocktailRecipeFull;
@@ -693,12 +694,7 @@ export default function CalculationPage() {
                             {showSalesStuff ? (
                               <>
                                 <td>
-                                  <span>{`${
-                                    cocktail.cocktail.price?.toLocaleString(undefined, {
-                                      minimumFractionDigits: 0,
-                                      maximumFractionDigits: 2,
-                                    }) ?? '-'
-                                  } €`}</span>
+                                  <span>{`${cocktail.cocktail.price?.formatPrice() ?? '-'} €`}</span>
                                 </td>
                                 <td>
                                   <div className={'join print:hidden'}>
@@ -723,13 +719,7 @@ export default function CalculationPage() {
                                     />
                                     <span className={'btn btn-secondary join-item btn-sm'}> €</span>
                                   </div>
-                                  <div className={'hidden print:flex'}>
-                                    {cocktail.customPrice?.toLocaleString(undefined, {
-                                      minimumFractionDigits: 0,
-                                      maximumFractionDigits: 2,
-                                    }) ?? '-'}{' '}
-                                    €
-                                  </div>
+                                  <div className={'hidden print:flex'}>{cocktail.customPrice?.formatPrice() ?? '-'} €</div>
                                 </td>
                               </>
                             ) : (
@@ -815,37 +805,16 @@ export default function CalculationPage() {
                             <tr key={'cocktail-' + cocktail.cocktail.id}>
                               <td>{cocktail.cocktail.name}</td>
                               <td>{cocktail.plannedAmount} x</td>
-                              <td>
-                                {calcCocktailTotalPrice(cocktail.cocktail, ingredients).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}{' '}
-                                €
-                              </td>
-                              <td>
-                                {(cocktail.plannedAmount * calcCocktailTotalPrice(cocktail.cocktail, ingredients)).toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}{' '}
-                                €
-                              </td>
+                              <td>{calcCocktailTotalPrice(cocktail.cocktail, ingredients).formatPrice()} €</td>
+                              <td>{(cocktail.plannedAmount * calcCocktailTotalPrice(cocktail.cocktail, ingredients)).formatPrice()} €</td>
                               {showSalesStuff ? (
                                 <>
-                                  <td>
-                                    {(cocktail.plannedAmount * (cocktail.customPrice ?? cocktail.cocktail.price ?? 0)).toLocaleString(undefined, {
-                                      minimumFractionDigits: 2,
-                                      maximumFractionDigits: 2,
-                                    })}
-                                    €
-                                  </td>
+                                  <td>{(cocktail.plannedAmount * (cocktail.customPrice ?? cocktail.cocktail.price ?? 0)).formatPrice()}€</td>
                                   <td>
                                     {(
                                       cocktail.plannedAmount * (cocktail.customPrice ?? cocktail.cocktail.price ?? 0) -
                                       cocktail.plannedAmount * calcCocktailTotalPrice(cocktail.cocktail, ingredients)
-                                    ).toLocaleString(undefined, {
-                                      minimumFractionDigits: 2,
-                                      maximumFractionDigits: 2,
-                                    })}{' '}
+                                    ).formatPrice()}{' '}
                                     €
                                   </td>
                                 </>
@@ -873,10 +842,7 @@ export default function CalculationPage() {
                           {cocktailCalculationItems
                             .map((cocktail) => cocktail.plannedAmount * calcCocktailTotalPrice(cocktail.cocktail, ingredients))
                             .reduce((acc, curr) => acc + curr, 0)
-                            .toLocaleString(undefined, {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2,
-                            })}{' '}
+                            .formatPrice()}{' '}
                           €
                         </td>
                         {showSalesStuff ? (
@@ -885,10 +851,7 @@ export default function CalculationPage() {
                               {cocktailCalculationItems
                                 .map((cocktail) => cocktail.plannedAmount * (cocktail.customPrice ?? cocktail.cocktail.price ?? 0))
                                 .reduce((acc, curr) => acc + curr, 0)
-                                .toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}{' '}
+                                .formatPrice()}{' '}
                               €
                             </td>
                             <td>
@@ -899,10 +862,7 @@ export default function CalculationPage() {
                                     cocktail.plannedAmount * calcCocktailTotalPrice(cocktail.cocktail, ingredients),
                                 )
                                 .reduce((acc, curr) => acc + curr, 0)
-                                .toLocaleString(undefined, {
-                                  minimumFractionDigits: 2,
-                                  maximumFractionDigits: 2,
-                                })}{' '}
+                                .formatPrice()}{' '}
                               €
                             </td>
                           </>

--- a/pages/workspaces/[workspaceId]/manage/cocktails/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/cocktails/index.tsx
@@ -84,13 +84,7 @@ export default function CocktailsOverviewPage() {
             {cocktailRecipe.name} {isArchived && '(Archiviert)'}
           </td>
           <td className={''}>
-            <span className={'whitespace-nowrap'}>
-              {cocktailRecipe.price?.toLocaleString(undefined, {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 2,
-              }) ?? '-'}{' '}
-              €
-            </span>
+            <span className={'whitespace-nowrap'}>{cocktailRecipe.price?.formatPrice() ?? '-'} €</span>
           </td>
           <td className={'flex items-center gap-1'}>
             {cocktailRecipe.tags.map((tag) => (

--- a/pages/workspaces/[workspaceId]/manage/garnishes/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/garnishes/index.tsx
@@ -97,13 +97,7 @@ export default function ManageGlassesOverviewPage() {
                         <td>
                           <div className="font-bold">{garnish.name}</div>
                         </td>
-                        <td>
-                          {garnish.price?.toLocaleString(undefined, {
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          }) ?? '-'}{' '}
-                          €
-                        </td>
+                        <td>{garnish.price?.formatPrice() ?? '-'} €</td>
                         <ManageColumn
                           entity={'garnishes'}
                           id={garnish.id}

--- a/pages/workspaces/[workspaceId]/manage/glasses/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/glasses/index.tsx
@@ -14,6 +14,7 @@ import AvatarImage from '../../../../../components/AvatarImage';
 import { fetchGlasses } from '@lib/network/glasses';
 import ImageModal from '../../../../../components/modals/ImageModal';
 import { ModalContext } from '@lib/context/ModalContextProvider';
+import '../../../../../lib/NumberUtils';
 
 export default function ManageGlassesOverviewPage() {
   const router = useRouter();
@@ -102,13 +103,7 @@ export default function ManageGlassesOverviewPage() {
                         <td>
                           <div className="font-bold">{glass.name}</div>
                         </td>
-                        <td>
-                          {glass.deposit.toLocaleString(undefined, {
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          })}{' '}
-                          €
-                        </td>
+                        <td>{glass.deposit.formatPrice()} €</td>
                         <ManageColumn entity={'glasses'} id={glass.id} name={glass.name} onRefresh={() => fetchGlasses(workspaceId, setGlasses, setLoading)} />
                       </tr>
                     ))

--- a/pages/workspaces/[workspaceId]/manage/ingredients/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/ingredients/index.tsx
@@ -13,6 +13,7 @@ import { IngredientModel } from '../../../../../models/IngredientModel';
 import { ModalContext } from '@lib/context/ModalContextProvider';
 import { fetchIngredients } from '@lib/network/ingredients';
 import ImageModal from '../../../../../components/modals/ImageModal';
+import '../../../../../lib/NumberUtils';
 
 export default function IngredientsOverviewPage() {
   const router = useRouter();
@@ -132,13 +133,7 @@ export default function IngredientsOverviewPage() {
                             <span>Anzeigen</span>
                           </button>
                         </td>
-                        <td className={'whitespace-nowrap'}>
-                          {ingredient.price?.toLocaleString(undefined, {
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 2,
-                          }) ?? '-'}{' '}
-                          €
-                        </td>
+                        <td className={'whitespace-nowrap'}>{ingredient.price?.formatPrice() ?? '-'} €</td>
                         <td className={''}>
                           {ingredient.IngredientVolume.map((volume) => (
                             <div key={`ingredient-${ingredient.id}-volume-unit-${volume.id}`} className={'whitespace-nowrap'}>
@@ -149,11 +144,7 @@ export default function IngredientsOverviewPage() {
                         <td>
                           {ingredient.IngredientVolume.map((volume) => (
                             <div key={`ingredient-${ingredient.id}-volume-unit-price-${volume.id}`} className={'whitespace-nowrap'}>
-                              {((ingredient.price ?? 0) / volume.volume).toLocaleString(undefined, {
-                                minimumFractionDigits: 0,
-                                maximumFractionDigits: 2,
-                              })}{' '}
-                              €/{userContext.getTranslation(volume.unit.name, 'de')}
+                              {((ingredient.price ?? 0) / volume.volume).formatPrice()} €/{userContext.getTranslation(volume.unit.name, 'de')}
                             </div>
                           ))}
                         </td>


### PR DESCRIPTION
## Closing issues:

- Closes: #581 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I´e created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I´ve tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Describe your work, what changed

As @ibot3 described in #581, prices should always be displayed with two decimal places. The cocktail card and detail modal will only show two decimal places unless the value is zero. 

## Affected sites (please check during review):

- [ ] [workspaceId]/index.tsx - Cocktail Card and Dialog
- [ ] [workspaceId]/manage/<ingredients|glasses|cocktails|garnishes>/<index|[id]> - All prices have now 2 digits
- [ ] [workspaceId]/manage/calculation/<create|[id]>

## Further comments

I hope i catched all prices to format them properly.