### PR TITLE
feat: Make Cocktail search ignore diacritics

### DIFF
--- a/lib/StringUtils.ts
+++ b/lib/StringUtils.ts
@@ -18,3 +18,15 @@ String.prototype.string2color = function () {
   }
   return colour;
 };
+
+export function normalizeString(s: string | undefined): string {
+  if (s == undefined) {
+    return '';
+  }
+  // https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
+  return s
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}

--- a/lib/cocktailFilter.ts
+++ b/lib/cocktailFilter.ts
@@ -1,14 +1,15 @@
 import { CocktailRecipeModel } from '../models/CocktailRecipeModel';
+import { normalizeString } from '../lib/StringUtils';
 
 export const cocktailFilter = (filterString: string) => {
-  const lowerCaseFilterString = filterString.toLowerCase();
+  const filterFor = normalizeString(filterString);
 
   return function (cocktailRecipe: CocktailRecipeModel): boolean {
     return (
-      cocktailRecipe.name.toLowerCase().includes(lowerCaseFilterString) ||
-      cocktailRecipe.glass?.name.toLowerCase().includes(lowerCaseFilterString) ||
-      cocktailRecipe.garnishes.some((garnish) => garnish.garnish.name.toLowerCase().includes(lowerCaseFilterString)) ||
-      cocktailRecipe.tags.some((tag) => tag.toLowerCase().includes(lowerCaseFilterString))
+      normalizeString(cocktailRecipe.name).includes(filterFor) ||
+      normalizeString(cocktailRecipe.glass?.name).includes(filterFor) ||
+      cocktailRecipe.garnishes.some((garnish) => normalizeString(garnish.garnish.name).includes(filterFor)) ||
+      cocktailRecipe.tags.some((tag) => normalizeString(tag).includes(filterFor))
     );
   };
 };

--- a/pages/api/workspaces/[workspaceId]/cocktails/index.tsx
+++ b/pages/api/workspaces/[workspaceId]/cocktails/index.tsx
@@ -9,6 +9,7 @@ import { CocktailRecipeGarnishFull } from '../../../../../models/CocktailRecipeG
 import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
 import HTTPMethod from 'http-method-enum';
 import { withHttpMethods } from '@middleware/api/handleMethods';
+import { normalizeString } from '../../../../../lib/StringUtils';
 import CocktailRecipeCreateInput = Prisma.CocktailRecipeCreateInput;
 
 export const config = {
@@ -52,19 +53,19 @@ export default withHttpMethods({
     if (searchParam == undefined) {
       return res.json({ data: cocktailRecipes });
     } else {
-      const search = searchParam.trim().toLowerCase();
+      const search = normalizeString(searchParam);
       const result = cocktailRecipes.filter(
         (cocktail) =>
-          cocktail.name.toLowerCase().includes(search) ||
-          (cocktail.tags.some((tag) => tag.toLowerCase().includes(search)) && search.length >= 3) ||
-          (cocktail.garnishes.some((garnish) => garnish.garnish.name.toLowerCase().includes(search)) && search.length >= 3) ||
+          normalizeString(cocktail.name).includes(search) ||
+          (cocktail.tags.some((tag) => normalizeString(tag).includes(search)) && search.length >= 3) ||
+          (cocktail.garnishes.some((garnish) => normalizeString(garnish.garnish.name).includes(search)) && search.length >= 3) ||
           cocktail.steps.some((step) =>
             step.ingredients
               .filter((ingredient) => ingredient.ingredient?.name != undefined)
               .some(
                 (ingredient) =>
-                  (ingredient.ingredient?.name.toLowerCase().includes(search) && search.length >= 3) ||
-                  ((ingredient.ingredient?.shortName ?? '').toLowerCase().includes(search) && search.length >= 3),
+                  (normalizeString(ingredient.ingredient?.name).includes(search) && search.length >= 3) ||
+                  (normalizeString(ingredient.ingredient?.shortName ?? '').includes(search) && search.length >= 3),
               ),
           ),
       );


### PR DESCRIPTION
This commit fixes issue #806, by making both cocktail searches (settings and the main one) normalize the needle and haystack before searching, by removing diacritics.

As some other things (e.g. the 'Ein ähnlicher Cocktail existiert bereits'), already use levenshtein distances, it may be a good idea to make these searches fuzzy in the future.

Search logic could also be further simplified by just concatenating all the possible strings together, however with this commit I aimed to change as few things as possible.

## Closing issues:

- Closes: #806 

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I´e created all necessary migrations? (none)
- [X] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [X] No build errors (`pnpm build`)
- [X] I´ve tested the implemented function by my own
- [X] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard
