### PR TITLE
feat: signage monitor enhancement, multi slide and PDF

### DIFF
--- a/components/UploadDropZone.tsx
+++ b/components/UploadDropZone.tsx
@@ -7,7 +7,12 @@ import { Button, Divider } from '@components/ui';
 
 interface UploadDropZoneProps {
   onSelectedFilesChanged: (file: File | undefined) => void;
+  onFilesSelected?: (files: File[]) => void;
   maxUploadSize?: string;
+  multiple?: boolean;
+  accept?: string;
+  label?: string;
+  hint?: string;
 }
 
 export function UploadDropZone(props: UploadDropZoneProps) {
@@ -15,6 +20,22 @@ export function UploadDropZone(props: UploadDropZoneProps) {
   const [showUrlInput, setShowUrlInput] = useState(false);
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const accept = props.accept ?? 'image/*';
+  const label = props.label ?? 'Bild wählen';
+  const hint = props.hint ?? '(z.B. SVG, PNG, JPG oder GIF)';
+
+  const handleFiles = (fileList: FileList | null | undefined) => {
+    if (!fileList || fileList.length === 0) {
+      return;
+    }
+
+    if (props.multiple) {
+      props.onFilesSelected?.(Array.from(fileList));
+      return;
+    }
+
+    props.onSelectedFilesChanged(fileList[0]);
+  };
 
   const handleUrlImport = async (imageUrl: string) => {
     try {
@@ -52,10 +73,9 @@ export function UploadDropZone(props: UploadDropZoneProps) {
                   name="file"
                   className="hidden"
                   capture="environment"
-                  accept="image/*"
+                  accept={accept}
                   onChange={(event) => {
-                    const file = event?.target?.files?.[0];
-                    props.onSelectedFilesChanged(file);
+                    handleFiles(event?.target?.files);
                   }}
                 />
                 <Button variant="outline" type="button" onClick={() => fileInputRef.current?.click()}>
@@ -66,10 +86,10 @@ export function UploadDropZone(props: UploadDropZoneProps) {
                   type="file"
                   name="file"
                   className="hidden"
-                  accept="image/*"
+                  accept={accept}
+                  multiple={props.multiple}
                   onChange={(event) => {
-                    const file = event?.target?.files?.[0];
-                    props.onSelectedFilesChanged(file);
+                    handleFiles(event?.target?.files);
                   }}
                 />
                 <Button variant="outline" type="button" onClick={() => setShowUrlInput(true)}>
@@ -91,7 +111,7 @@ export function UploadDropZone(props: UploadDropZoneProps) {
               htmlFor={'dropzone-file-' + identifier}
               className="flex h-full w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-base-300 bg-base-200 hover:border-base-300 hover:bg-base-100 dark:bg-base-200 dark:hover:bg-base-100"
             >
-              <div className="text-2xl font-bold">Bild wählen</div>
+              <div className="text-2xl font-bold">{label}</div>
               <div className="flex flex-col items-center justify-center pt-5 pb-6">
                 <svg
                   aria-hidden="true"
@@ -111,7 +131,7 @@ export function UploadDropZone(props: UploadDropZoneProps) {
                 <p className="mb-2 text-sm text-base-content">
                   <span className="font-semibold">Klicken, zum auswählen</span> oder ziehen
                 </p>
-                <p className="text-xs text-base-content">(z.B. SVG, PNG, JPG oder GIF)</p>
+                <p className="text-xs text-base-content">{hint}</p>
                 {props.maxUploadSize && (
                   <p className="text-xs text-base-content">
                     Maximale Datei-Größe: <strong>{props.maxUploadSize}</strong>
@@ -123,19 +143,23 @@ export function UploadDropZone(props: UploadDropZoneProps) {
                 type="file"
                 name={`file-${identifier}`}
                 className="hidden"
-                accept="image/*"
+                accept={accept}
+                multiple={props.multiple}
                 onChange={(event) => {
-                  const file = event?.target?.files?.[0];
-                  props.onSelectedFilesChanged(file);
+                  handleFiles(event?.target?.files);
                 }}
               />
             </label>
-            <Divider className="my-4 flex items-center gap-4 before:content-none after:content-none">
-              <span className="h-px flex-1 bg-base-content/15" />
-              <span className="text-sm text-base-content/70">Bild über URL laden</span>
-              <span className="h-px flex-1 bg-base-content/15" />
-            </Divider>
-            <ImportPhotoByUrl onImport={handleUrlImport} />
+            {!props.multiple ? (
+              <>
+                <Divider className="my-4 flex items-center gap-4 before:content-none after:content-none">
+                  <span className="h-px flex-1 bg-base-content/15" />
+                  <span className="text-sm text-base-content/70">Bild über URL laden</span>
+                  <span className="h-px flex-1 bg-base-content/15" />
+                </Divider>
+                <ImportPhotoByUrl onImport={handleUrlImport} />
+              </>
+            ) : null}
           </div>
         )}
       </div>

--- a/components/signage/SignageMonitorPreview.tsx
+++ b/components/signage/SignageMonitorPreview.tsx
@@ -1,0 +1,71 @@
+import { useContext, useMemo } from 'react';
+import { cn } from '@components/ui';
+import { SignageFormatView } from '@lib/signage/types';
+import { filterSlidesForDisplay } from '@lib/signage/isSlideActiveNow';
+import { resolveSignageSlides } from '@lib/signage/signageApiHelpers';
+import { getSignageContainerClassName, getSignageContainerStyle } from '@lib/signage/signageBackground';
+import { ModalContext } from '@lib/context/ModalContextProvider';
+import { SignageSlideDisplay } from './SignageSlideDisplay';
+
+interface SignageMonitorPreviewProps {
+  format: SignageFormatView;
+  allFormats?: SignageFormatView[];
+  variant?: 'inline' | 'modal';
+}
+
+function SignageMonitorPreviewContent({ format, allFormats, variant }: SignageMonitorPreviewProps) {
+  const displaySlides = useMemo(() => {
+    if (allFormats && allFormats.length > 0) {
+      return resolveSignageSlides(allFormats, format.format);
+    }
+    return format.slides;
+  }, [allFormats, format.format, format.slides]);
+
+  const slides = filterSlidesForDisplay(displaySlides);
+  const isPortrait = format.format === 'PORTRAIT';
+  const backgroundMode = format.backgroundMode ?? 'COLOR';
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-lg border border-base-300',
+        getSignageContainerClassName(backgroundMode, format.backgroundColor),
+        variant === 'modal'
+          ? isPortrait
+            ? 'mx-auto aspect-9/16 h-[80vh] w-auto'
+            : 'mx-auto aspect-video w-[min(90vw,64rem)]'
+          : isPortrait
+            ? 'mx-auto aspect-9/16 h-96 w-auto'
+            : 'aspect-video w-full',
+      )}
+      style={getSignageContainerStyle(backgroundMode, format.backgroundColor)}
+    >
+      <SignageSlideDisplay
+        slides={slides}
+        slideDurationSeconds={format.slideDurationSeconds}
+        backgroundMode={backgroundMode}
+        emptyMessage="Keine aktive Karte für jetzt"
+        alt="Monitor preview slide"
+      />
+    </div>
+  );
+}
+
+export function SignageMonitorPreview({ format, allFormats, variant = 'inline' }: SignageMonitorPreviewProps) {
+  const modalContext = useContext(ModalContext);
+
+  if (variant === 'modal') {
+    return <SignageMonitorPreviewContent format={format} allFormats={allFormats} variant="modal" />;
+  }
+
+  return (
+    <button
+      type="button"
+      className="block w-full cursor-zoom-in text-left"
+      onClick={() => modalContext.openModal(<SignageMonitorPreviewContent format={format} allFormats={allFormats} variant="modal" />)}
+      title="Monitor-Vorschau vergrößern"
+    >
+      <SignageMonitorPreviewContent format={format} allFormats={allFormats} variant="inline" />
+    </button>
+  );
+}

--- a/components/signage/SignageSlideBulkActions.tsx
+++ b/components/signage/SignageSlideBulkActions.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { DAY_ORDER_MONDAY_FIRST, getDayName } from '@lib/dayConstants';
+import { Button, Checkbox, FormControl, Input, Label, LabelText } from '@components/ui';
+
+interface SignageSlideBulkActionsProps {
+  selectedCount: number;
+  onApply: (payload: { weekdays: number[]; validFrom: string | null; validTo: string | null; dateExclusive: boolean }) => Promise<void>;
+  onDisable: () => Promise<void>;
+  onEnable: () => Promise<void>;
+  onClearSelection: () => void;
+}
+
+export function SignageSlideBulkActions({ selectedCount, onApply, onDisable, onEnable, onClearSelection }: SignageSlideBulkActionsProps) {
+  const [weekdays, setWeekdays] = useState<number[]>([]);
+  const [validFrom, setValidFrom] = useState('');
+  const [validTo, setValidTo] = useState('');
+  const [dateExclusive, setDateExclusive] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  const toggleWeekday = (day: number) => {
+    setWeekdays((current) => (current.includes(day) ? current.filter((value) => value !== day) : [...current, day]));
+  };
+
+  const handleApply = async () => {
+    setSubmitting(true);
+    try {
+      await onApply({
+        weekdays,
+        validFrom: validFrom || null,
+        validTo: validTo || null,
+        dateExclusive,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-primary/30 bg-primary/5 p-3">
+      <div className="text-sm font-medium">{selectedCount} Slide(s) ausgewählt</div>
+
+      <div className="flex flex-wrap gap-1">
+        {DAY_ORDER_MONDAY_FIRST.map((day) => (
+          <Button key={day} type="button" size="sm" variant={weekdays.includes(day) ? 'primary' : 'outline'} onClick={() => toggleWeekday(day)}>
+            {getDayName(day, true, true)}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <FormControl>
+          <Label>
+            <LabelText>Startdatum</LabelText>
+          </Label>
+          <Input type="date" value={validFrom} onChange={(event) => setValidFrom(event.target.value)} />
+        </FormControl>
+        <FormControl>
+          <Label>
+            <LabelText>Enddatum</LabelText>
+          </Label>
+          <Input type="date" value={validTo} onChange={(event) => setValidTo(event.target.value)} />
+        </FormControl>
+      </div>
+
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox checked={dateExclusive} onChange={() => setDateExclusive((current) => !current)} />
+        <span>
+          Nur in diesem Zeitraum anzeigen (ersetzt andere Karten)
+          <span className="mt-0.5 block text-xs text-base-content/60">Exklusive Karten ersetzen die normale Rotation, solange sie aktiv sind.</span>
+        </span>
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" variant="primary" size="sm" disabled={submitting} onClick={handleApply}>
+          Anwenden
+        </Button>
+        <Button type="button" variant="outline" size="sm" disabled={submitting} onClick={onEnable}>
+          Aktivieren
+        </Button>
+        <Button type="button" variant="outline" size="sm" disabled={submitting} onClick={onDisable}>
+          Deaktivieren
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onClearSelection}>
+          Auswahl aufheben
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/signage/SignageSlideDisplay.tsx
+++ b/components/signage/SignageSlideDisplay.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
+import { cn } from '@components/ui';
+import { SignageBackgroundMode } from '@lib/signage/types';
+
+interface SignageSlideDisplayProps {
+  slides: { id: string; content: string }[];
+  slideDurationSeconds: number;
+  backgroundMode?: SignageBackgroundMode;
+  className?: string;
+  emptyMessage?: string;
+  alt?: string;
+}
+
+export function SignageSlideDisplay({
+  slides,
+  slideDurationSeconds,
+  backgroundMode = 'COLOR',
+  className,
+  emptyMessage = 'No active slide',
+  alt = 'Monitor slide',
+}: SignageSlideDisplayProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const slidesKey = useMemo(() => slides.map((slide) => slide.id).join(','), [slides]);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [slidesKey, slideDurationSeconds]);
+
+  useEffect(() => {
+    if (slides.length <= 1) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setCurrentIndex((current) => (current + 1) % slides.length);
+    }, slideDurationSeconds * 1000);
+
+    return () => window.clearInterval(interval);
+  }, [slideDurationSeconds, slides.length]);
+
+  if (slides.length === 0) {
+    return <div className={cn('flex h-full items-center justify-center text-sm text-base-content/70', className)}>{emptyMessage}</div>;
+  }
+
+  return (
+    <div className={cn('relative h-full w-full', className)}>
+      {backgroundMode === 'BLURRED' ? (
+        <div className="absolute inset-0 z-0 overflow-hidden" aria-hidden>
+          {slides.map((slide, index) => (
+            <div
+              key={`blur-${slide.id}`}
+              className={cn(
+                'absolute inset-0 transition-opacity duration-700 ease-in-out motion-reduce:transition-none',
+                index === currentIndex ? 'opacity-100' : 'opacity-0',
+              )}
+            >
+              <Image src={slide.content} alt="" fill className="scale-110 object-cover blur-2xl" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="relative z-10 h-full w-full">
+        {slides.map((slide, index) => (
+          <div
+            key={slide.id}
+            className={cn(
+              'absolute inset-0 transition-opacity duration-700 ease-in-out motion-reduce:transition-none',
+              index === currentIndex ? 'opacity-100' : 'opacity-0',
+            )}
+            aria-hidden={index !== currentIndex}
+          >
+            <div className="relative h-full w-full">
+              <Image src={slide.content} alt={index === currentIndex ? alt : ''} fill className="object-contain" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/signage/SignageSlideFilter.tsx
+++ b/components/signage/SignageSlideFilter.tsx
@@ -1,0 +1,67 @@
+import { DAY_ORDER_MONDAY_FIRST, getDayName } from '@lib/dayConstants';
+import { SignageSlideFilterState } from '@lib/signage/types';
+import { Button, FormControl, Input, Label, LabelText, Select } from '@components/ui';
+
+interface SignageSlideFilterProps {
+  value: SignageSlideFilterState;
+  onChange: (value: SignageSlideFilterState) => void;
+}
+
+export function SignageSlideFilter({ value, onChange }: SignageSlideFilterProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-base-300/60 bg-base-100 p-3">
+      <FormControl>
+        <Label>
+          <LabelText>Filter</LabelText>
+        </Label>
+        <Select
+          value={value.mode}
+          onChange={(event) =>
+            onChange({
+              ...value,
+              mode: event.target.value as SignageSlideFilterState['mode'],
+            })
+          }
+        >
+          <option value="all">Alle</option>
+          <option value="activeNow">Aktuell aktiv</option>
+          <option value="weekday">Wochentag</option>
+          <option value="dateRange">Zeitraum</option>
+        </Select>
+      </FormControl>
+
+      {value.mode === 'weekday' ? (
+        <div className="flex flex-wrap gap-1">
+          {DAY_ORDER_MONDAY_FIRST.map((day) => (
+            <Button
+              key={day}
+              type="button"
+              size="sm"
+              variant={value.weekday === day ? 'primary' : 'outline'}
+              onClick={() => onChange({ ...value, weekday: day })}
+            >
+              {getDayName(day, true, true)}
+            </Button>
+          ))}
+        </div>
+      ) : null}
+
+      {value.mode === 'dateRange' ? (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <FormControl>
+            <Label>
+              <LabelText>Von</LabelText>
+            </Label>
+            <Input type="date" value={value.dateFrom ?? ''} onChange={(event) => onChange({ ...value, dateFrom: event.target.value })} />
+          </FormControl>
+          <FormControl>
+            <Label>
+              <LabelText>Bis</LabelText>
+            </Label>
+            <Input type="date" value={value.dateTo ?? ''} onChange={(event) => onChange({ ...value, dateTo: event.target.value })} />
+          </FormControl>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/signage/SignageSlideList.tsx
+++ b/components/signage/SignageSlideList.tsx
@@ -1,0 +1,260 @@
+import { useContext, useState } from 'react';
+import { DndContext, DragEndEvent, PointerSensor, closestCenter, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import Image from 'next/image';
+import { FaCalendarAlt, FaEye, FaEyeSlash, FaGripVertical, FaTrashAlt } from 'react-icons/fa';
+import { Button, Checkbox, FormControl, Input, Label, LabelText } from '@components/ui';
+import { DAY_ORDER_MONDAY_FIRST, getDayName } from '@lib/dayConstants';
+import { formatSlideScheduleLabel } from '@lib/signage/isSlideActiveNow';
+import { SignageSlideView } from '@lib/signage/types';
+import { ModalContext } from '@lib/context/ModalContextProvider';
+import ImageModal from '@components/modals/ImageModal';
+
+export interface SignageSlideSchedulePayload {
+  weekdays: number[];
+  validFrom: string | null;
+  validTo: string | null;
+  dateExclusive: boolean;
+}
+
+interface SignageSlideListProps {
+  slides: SignageSlideView[];
+  selectedIds: Set<string>;
+  onChange: (slides: SignageSlideView[]) => void;
+  onToggleSelect: (slideId: string) => void;
+  onToggleSelectAll: () => void;
+  onToggleEnabled: (slideId: string, enabled: boolean) => Promise<void>;
+  onDelete: (slideId: string) => Promise<void>;
+  onScheduleApply: (slideId: string, payload: SignageSlideSchedulePayload) => Promise<void>;
+}
+
+function SlideSchedulePanel({
+  slide,
+  onApply,
+  onClose,
+}: {
+  slide: SignageSlideView;
+  onApply: (payload: SignageSlideSchedulePayload) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [weekdays, setWeekdays] = useState<number[]>(slide.weekdays);
+  const [validFrom, setValidFrom] = useState(slide.validFrom ?? '');
+  const [validTo, setValidTo] = useState(slide.validTo ?? '');
+  const [dateExclusive, setDateExclusive] = useState(slide.dateExclusive);
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggleWeekday = (day: number) => {
+    setWeekdays((current) => (current.includes(day) ? current.filter((value) => value !== day) : [...current, day]));
+  };
+
+  const handleApply = async () => {
+    setSubmitting(true);
+    try {
+      await onApply({
+        weekdays,
+        validFrom: validFrom || null,
+        validTo: validTo || null,
+        dateExclusive,
+      });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 flex flex-col gap-3 rounded-lg border border-base-300/60 bg-base-200/40 p-3">
+      <div className="flex flex-wrap gap-1">
+        {DAY_ORDER_MONDAY_FIRST.map((day) => (
+          <Button key={day} type="button" size="sm" variant={weekdays.includes(day) ? 'primary' : 'outline'} onClick={() => toggleWeekday(day)}>
+            {getDayName(day, true, true)}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <FormControl>
+          <Label>
+            <LabelText>Startdatum</LabelText>
+          </Label>
+          <Input type="date" value={validFrom} onChange={(event) => setValidFrom(event.target.value)} />
+        </FormControl>
+        <FormControl>
+          <Label>
+            <LabelText>Enddatum</LabelText>
+          </Label>
+          <Input type="date" value={validTo} onChange={(event) => setValidTo(event.target.value)} />
+        </FormControl>
+      </div>
+
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox checked={dateExclusive} onChange={() => setDateExclusive((current) => !current)} />
+        <span>
+          Nur in diesem Zeitraum anzeigen (ersetzt andere Karten)
+          <span className="mt-0.5 block text-xs text-base-content/60">Exklusive Karten ersetzen die normale Rotation, solange sie aktiv sind.</span>
+        </span>
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" variant="primary" size="sm" disabled={submitting} onClick={handleApply}>
+          Anwenden
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+          Schließen
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SortableSlideItem({
+  id,
+  slide,
+  selected,
+  expanded,
+  onToggleSelect,
+  onToggleEnabled,
+  onToggleSchedule,
+  onDelete,
+  onScheduleApply,
+  onCloseSchedule,
+}: {
+  id: string;
+  slide: SignageSlideView;
+  selected: boolean;
+  expanded: boolean;
+  onToggleSelect: () => void;
+  onToggleEnabled: () => Promise<void>;
+  onToggleSchedule: () => void;
+  onDelete: () => Promise<void>;
+  onScheduleApply: (payload: SignageSlideSchedulePayload) => Promise<void>;
+  onCloseSchedule: () => void;
+}) {
+  const modalContext = useContext(ModalContext);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`relative flex flex-col rounded-lg border p-2 ${slide.enabled ? 'border-base-300/60 bg-base-100' : 'border-base-300/40 bg-base-200/60 opacity-70'}`}
+    >
+      <div className="flex min-h-28 items-center gap-2">
+        <Checkbox checked={selected} onChange={onToggleSelect} />
+        <button type="button" className="cursor-grab text-base-content/60" {...attributes} {...listeners}>
+          <FaGripVertical />
+        </button>
+        <button
+          type="button"
+          className={`relative h-24 w-32 shrink-0 overflow-hidden rounded-md ${slide.enabled ? '' : 'opacity-50 grayscale'} cursor-zoom-in`}
+          onClick={() => modalContext.openModal(<ImageModal image={slide.content} />)}
+          title="Vorschau vergrößern"
+        >
+          <Image src={slide.content} alt="Monitor slide preview" fill className="object-contain" />
+        </button>
+        <div className="min-w-0 flex-1 text-xs text-base-content/70">{formatSlideScheduleLabel(slide)}</div>
+        <div className="flex gap-1">
+          <Button type="button" variant={expanded ? 'primary' : 'outline'} shape="square" size="sm" onClick={onToggleSchedule} title="Zeitplan bearbeiten">
+            <FaCalendarAlt />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            shape="square"
+            size="sm"
+            onClick={() => onToggleEnabled()}
+            title={slide.enabled ? 'Deaktivieren' : 'Aktivieren'}
+          >
+            {slide.enabled ? <FaEye /> : <FaEyeSlash />}
+          </Button>
+          <Button type="button" variant="outline" shape="square" size="sm" className="border-error text-error hover:bg-error/10" onClick={() => onDelete()}>
+            <FaTrashAlt />
+          </Button>
+        </div>
+      </div>
+      {expanded ? (
+        <SlideSchedulePanel
+          key={`${slide.id}-${slide.weekdays.join(',')}-${slide.validFrom ?? ''}-${slide.validTo ?? ''}-${slide.dateExclusive}`}
+          slide={slide}
+          onApply={onScheduleApply}
+          onClose={onCloseSchedule}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function SignageSlideList({
+  slides,
+  selectedIds,
+  onChange,
+  onToggleSelect,
+  onToggleSelectAll,
+  onToggleEnabled,
+  onDelete,
+  onScheduleApply,
+}: SignageSlideListProps) {
+  const [expandedSlideId, setExpandedSlideId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const ids = slides.map((slide) => slide.id);
+  const allSelected = slides.length > 0 && slides.every((slide) => selectedIds.has(slide.id));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = ids.indexOf(active.id as string);
+    const newIndex = ids.indexOf(over.id as string);
+    if (oldIndex === -1 || newIndex === -1) {
+      return;
+    }
+
+    const reordered = arrayMove(slides, oldIndex, newIndex).map((slide, index) => ({
+      ...slide,
+      order: index,
+    }));
+    onChange(reordered);
+  };
+
+  if (slides.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex items-center gap-2 text-sm">
+        <Checkbox checked={allSelected} onChange={onToggleSelectAll} />
+        Alle auswählen
+      </label>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-2">
+            {slides.map((slide) => (
+              <SortableSlideItem
+                key={slide.id}
+                id={slide.id}
+                slide={slide}
+                selected={selectedIds.has(slide.id)}
+                expanded={expandedSlideId === slide.id}
+                onToggleSelect={() => onToggleSelect(slide.id)}
+                onToggleEnabled={() => onToggleEnabled(slide.id, !slide.enabled)}
+                onToggleSchedule={() => setExpandedSlideId((current) => (current === slide.id ? null : slide.id))}
+                onDelete={() => onDelete(slide.id)}
+                onScheduleApply={(payload) => onScheduleApply(slide.id, payload)}
+                onCloseSchedule={() => setExpandedSlideId(null)}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}

--- a/lib/pdf/pdfToImages.ts
+++ b/lib/pdf/pdfToImages.ts
@@ -1,0 +1,59 @@
+export interface PdfToImagesOptions {
+  scale?: number;
+}
+
+async function getPdfJs() {
+  const pdfjs = await import('pdfjs-dist');
+
+  if (typeof window !== 'undefined' && !pdfjs.GlobalWorkerOptions.workerSrc) {
+    pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
+  }
+
+  return pdfjs;
+}
+
+export async function pdfToImageFiles(file: File, options: PdfToImagesOptions = {}): Promise<File[]> {
+  const { scale = 2 } = options;
+  const pdfjs = await getPdfJs();
+  const arrayBuffer = await file.arrayBuffer();
+  const pdf = await pdfjs.getDocument({ data: arrayBuffer }).promise;
+  const imageFiles: File[] = [];
+
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+    const page = await pdf.getPage(pageNumber);
+    const viewport = page.getViewport({ scale });
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+      throw new Error('Could not create canvas context for PDF rendering.');
+    }
+
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+
+    await page.render({
+      canvas,
+      canvasContext: context,
+      viewport,
+    }).promise;
+
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (result) => {
+          if (result) {
+            resolve(result);
+          } else {
+            reject(new Error(`Failed to convert PDF page ${pageNumber} to image.`));
+          }
+        },
+        'image/jpeg',
+        0.9,
+      );
+    });
+
+    imageFiles.push(new File([blob], `${file.name.replace(/\.pdf$/i, '')}-page-${pageNumber}.jpg`, { type: 'image/jpeg' }));
+  }
+
+  return imageFiles;
+}

--- a/lib/signage/filterSlidesForAdmin.ts
+++ b/lib/signage/filterSlidesForAdmin.ts
@@ -1,0 +1,35 @@
+import { isSlideActiveNow } from './isSlideActiveNow';
+import { SignageSlideFilterState, SignageSlideView } from './types';
+
+function parseDate(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function rangesOverlap(slideFrom: string | null | undefined, slideTo: string | null | undefined, filterFrom: string, filterTo: string): boolean {
+  const slideStart = slideFrom ? parseDate(slideFrom) : new Date(0);
+  const slideEnd = slideTo ? parseDate(slideTo) : new Date(8640000000000000);
+  const filterStart = parseDate(filterFrom);
+  const filterEnd = parseDate(filterTo);
+
+  return slideStart.getTime() <= filterEnd.getTime() && slideEnd.getTime() >= filterStart.getTime();
+}
+
+export function filterSlidesForAdmin(slides: SignageSlideView[], filter: SignageSlideFilterState, referenceDate: Date = new Date()): SignageSlideView[] {
+  switch (filter.mode) {
+    case 'activeNow':
+      return slides.filter((slide) => isSlideActiveNow(slide, referenceDate));
+    case 'weekday':
+      if (filter.weekday === undefined) {
+        return slides;
+      }
+      return slides.filter((slide) => slide.weekdays.length === 0 || slide.weekdays.includes(filter.weekday!));
+    case 'dateRange':
+      if (!filter.dateFrom || !filter.dateTo) {
+        return slides;
+      }
+      return slides.filter((slide) => rangesOverlap(slide.validFrom, slide.validTo, filter.dateFrom!, filter.dateTo!));
+    default:
+      return slides;
+  }
+}

--- a/lib/signage/isSlideActiveNow.ts
+++ b/lib/signage/isSlideActiveNow.ts
@@ -1,0 +1,80 @@
+import { SignageSlideView } from './types';
+
+export interface SlideScheduleFields {
+  enabled: boolean;
+  weekdays: number[];
+  validFrom?: string | Date | null;
+  validTo?: string | Date | null;
+  dateExclusive?: boolean;
+}
+
+function toDateOnly(value: string | Date): Date {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function isSlideActiveNow(slide: SlideScheduleFields, referenceDate: Date = new Date()): boolean {
+  if (!slide.enabled) {
+    return false;
+  }
+
+  if (slide.weekdays.length > 0 && !slide.weekdays.includes(referenceDate.getDay())) {
+    return false;
+  }
+
+  const today = toDateOnly(referenceDate);
+
+  if (slide.validFrom) {
+    const from = toDateOnly(slide.validFrom);
+    if (today.getTime() < from.getTime()) {
+      return false;
+    }
+  }
+
+  if (slide.validTo) {
+    const to = toDateOnly(slide.validTo);
+    if (today.getTime() > to.getTime()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function filterSlidesForDisplay<T extends SignageSlideView>(slides: T[], referenceDate: Date = new Date()): T[] {
+  const activeSlides = slides.filter((slide) => isSlideActiveNow(slide, referenceDate));
+  const exclusiveSlides = activeSlides.filter((slide) => slide.dateExclusive);
+
+  if (exclusiveSlides.length > 0) {
+    return exclusiveSlides;
+  }
+
+  return activeSlides;
+}
+
+export function formatSlideScheduleLabel(slide: SlideScheduleFields): string {
+  const parts: string[] = [];
+
+  if (!slide.enabled) {
+    parts.push('Deaktiviert');
+  }
+
+  if (slide.dateExclusive) {
+    parts.push('Exklusiv');
+  }
+
+  if (slide.weekdays.length > 0) {
+    const dayLabels = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'];
+    parts.push(slide.weekdays.map((day) => dayLabels[day]).join(', '));
+  } else {
+    parts.push('Alle Wochentage');
+  }
+
+  if (slide.validFrom || slide.validTo) {
+    const from = slide.validFrom ? toDateOnly(slide.validFrom).toLocaleDateString('de-DE') : '…';
+    const to = slide.validTo ? toDateOnly(slide.validTo).toLocaleDateString('de-DE') : '…';
+    parts.push(`${from} – ${to}`);
+  }
+
+  return parts.join(' · ');
+}

--- a/lib/signage/parseRequestBody.ts
+++ b/lib/signage/parseRequestBody.ts
@@ -1,0 +1,6 @@
+export function parseRequestBody<T>(body: unknown): T {
+  if (typeof body === 'string') {
+    return JSON.parse(body) as T;
+  }
+  return body as T;
+}

--- a/lib/signage/processSignageFiles.ts
+++ b/lib/signage/processSignageFiles.ts
@@ -1,0 +1,34 @@
+import { compressFile } from '@lib/ImageCompressor';
+import { convertToBase64 } from '@lib/Base64Converter';
+import { pdfToImageFiles } from '@lib/pdf/pdfToImages';
+import { alertService } from '@lib/alertService';
+
+export async function processSignageFiles(files: File[]): Promise<string[]> {
+  const slides: string[] = [];
+
+  for (const file of files) {
+    try {
+      if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
+        const pageFiles = await pdfToImageFiles(file);
+        for (const pageFile of pageFiles) {
+          const compressed = await compressFile(pageFile);
+          slides.push(await convertToBase64(compressed));
+        }
+        continue;
+      }
+
+      if (!file.type.startsWith('image/')) {
+        alertService.error(`Dateityp nicht unterstützt: ${file.name}`);
+        continue;
+      }
+
+      const compressed = await compressFile(file);
+      slides.push(await convertToBase64(compressed));
+    } catch (error) {
+      console.error('processSignageFiles', error);
+      alertService.error(`Fehler beim Verarbeiten von ${file.name}`);
+    }
+  }
+
+  return slides;
+}

--- a/lib/signage/signageApiHelpers.ts
+++ b/lib/signage/signageApiHelpers.ts
@@ -1,0 +1,97 @@
+import { $Enums } from '@generated/prisma/client';
+import { SignageFormatView, SignageSlideView } from './types';
+
+type MonitorFormat = $Enums.MonitorFormat;
+
+export function mapSignageSlide(slide: {
+  id: string;
+  content: string;
+  order: number;
+  enabled: boolean;
+  weekdays: number[];
+  validFrom: Date | null;
+  validTo: Date | null;
+  dateExclusive: boolean;
+}): SignageSlideView {
+  return {
+    id: slide.id,
+    content: slide.content,
+    order: slide.order,
+    enabled: slide.enabled,
+    weekdays: slide.weekdays,
+    validFrom: slide.validFrom ? slide.validFrom.toISOString().slice(0, 10) : null,
+    validTo: slide.validTo ? slide.validTo.toISOString().slice(0, 10) : null,
+    dateExclusive: slide.dateExclusive,
+  };
+}
+
+export async function ensureSignageContainer(
+  tx: {
+    signage: {
+      findUnique: (args: { where: { workspaceId_format: { workspaceId: string; format: MonitorFormat } } }) => Promise<unknown>;
+      create: (args: { data: { workspaceId: string; format: MonitorFormat; slideDurationSeconds: number } }) => Promise<unknown>;
+    };
+  },
+  workspaceId: string,
+  format: MonitorFormat,
+) {
+  const existing = await tx.signage.findUnique({
+    where: {
+      workspaceId_format: {
+        workspaceId,
+        format,
+      },
+    },
+  });
+
+  if (!existing) {
+    await tx.signage.create({
+      data: {
+        workspaceId,
+        format,
+        slideDurationSeconds: 10,
+      },
+    });
+  }
+}
+
+export function resolveSignageSlides(
+  signages: Array<{
+    format: MonitorFormat | 'LANDSCAPE' | 'PORTRAIT';
+    mirrorSourceFormat?: MonitorFormat | 'LANDSCAPE' | 'PORTRAIT' | null;
+    slides: SignageSlideView[];
+  }>,
+  format: MonitorFormat | 'LANDSCAPE' | 'PORTRAIT',
+): SignageSlideView[] {
+  const signage = signages.find((entry) => entry.format === format);
+  if (!signage) {
+    return [];
+  }
+
+  if (signage.mirrorSourceFormat) {
+    const source = signages.find((entry) => entry.format === signage.mirrorSourceFormat);
+    return source?.slides ?? [];
+  }
+
+  return signage.slides;
+}
+
+export function mapSignageFormatView(signage: {
+  workspaceId: string;
+  format: MonitorFormat;
+  backgroundColor: string | null;
+  backgroundMode?: 'COLOR' | 'BLURRED';
+  slideDurationSeconds: number;
+  mirrorSourceFormat: MonitorFormat | null;
+  slides: SignageSlideView[];
+}): SignageFormatView {
+  return {
+    workspaceId: signage.workspaceId,
+    format: signage.format,
+    backgroundColor: signage.backgroundColor,
+    backgroundMode: signage.backgroundMode ?? 'COLOR',
+    slideDurationSeconds: signage.slideDurationSeconds,
+    mirrorSourceFormat: signage.mirrorSourceFormat,
+    slides: signage.slides,
+  };
+}

--- a/lib/signage/signageBackground.ts
+++ b/lib/signage/signageBackground.ts
@@ -1,0 +1,22 @@
+import type { CSSProperties } from 'react';
+import { SignageBackgroundMode } from './types';
+
+export function getSignageContainerStyle(backgroundMode: SignageBackgroundMode, backgroundColor?: string | null): CSSProperties | undefined {
+  if (backgroundMode === 'COLOR' && backgroundColor) {
+    return { backgroundColor };
+  }
+
+  return undefined;
+}
+
+export function getSignageContainerClassName(backgroundMode: SignageBackgroundMode, backgroundColor?: string | null, options?: { external?: boolean }): string {
+  if (backgroundMode === 'BLURRED') {
+    return 'bg-black';
+  }
+
+  if (backgroundMode === 'COLOR' && !backgroundColor) {
+    return options?.external ? 'bg-black' : 'bg-base-100';
+  }
+
+  return '';
+}

--- a/lib/signage/types.ts
+++ b/lib/signage/types.ts
@@ -1,0 +1,68 @@
+export interface SignageSlideOrderPayload {
+  id: string;
+  order: number;
+}
+
+export type SignageBackgroundMode = 'COLOR' | 'BLURRED';
+
+export interface SignageFormatSettingsPayload {
+  backgroundColor?: string | null;
+  backgroundMode?: SignageBackgroundMode;
+  slideDurationSeconds: number;
+  mirrorSourceFormat?: 'LANDSCAPE' | 'PORTRAIT' | null;
+  slides: SignageSlideOrderPayload[];
+}
+
+export interface SignageSettingsUpdatePayload {
+  landscape?: SignageFormatSettingsPayload;
+  portrait?: SignageFormatSettingsPayload;
+}
+
+export interface SignageSlideCreatePayload {
+  format: 'LANDSCAPE' | 'PORTRAIT';
+  slides: string[];
+}
+
+export interface SignageSlidePatchPayload {
+  slideIds: string[];
+  enabled?: boolean;
+  weekdays?: number[];
+  validFrom?: string | null;
+  validTo?: string | null;
+  dateExclusive?: boolean;
+}
+
+export interface SignageSlideView {
+  id: string;
+  content: string;
+  order: number;
+  enabled: boolean;
+  weekdays: number[];
+  validFrom?: string | null;
+  validTo?: string | null;
+  dateExclusive: boolean;
+}
+
+export interface SignageFormatView {
+  workspaceId: string;
+  format: 'LANDSCAPE' | 'PORTRAIT';
+  backgroundColor?: string | null;
+  backgroundMode: SignageBackgroundMode;
+  slideDurationSeconds: number;
+  mirrorSourceFormat?: 'LANDSCAPE' | 'PORTRAIT' | null;
+  slides: SignageSlideView[];
+}
+
+export type SignageSlideFilterMode = 'all' | 'activeNow' | 'weekday' | 'dateRange';
+
+export interface SignageSlideFilterState {
+  mode: SignageSlideFilterMode;
+  weekday?: number;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface ExclusiveConflict {
+  slideId: string;
+  label: string;
+}

--- a/lib/signage/validateExclusiveOverlap.ts
+++ b/lib/signage/validateExclusiveOverlap.ts
@@ -1,0 +1,94 @@
+import { formatSlideScheduleLabel } from './isSlideActiveNow';
+
+export interface ExclusiveOverlapSlide {
+  id: string;
+  dateExclusive: boolean;
+  enabled: boolean;
+  validFrom?: string | Date | null;
+  validTo?: string | Date | null;
+  weekdays?: number[];
+}
+
+export interface ExclusiveOverlapUpdate {
+  dateExclusive?: boolean;
+  enabled?: boolean;
+  validFrom?: string | null;
+  validTo?: string | null;
+}
+
+export interface ExclusiveOverlapConflict {
+  slideId: string;
+  label: string;
+}
+
+function toDateOnly(value: string | Date): Date {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function dateRangesOverlap(
+  fromA: string | Date | null | undefined,
+  toA: string | Date | null | undefined,
+  fromB: string | Date | null | undefined,
+  toB: string | Date | null | undefined,
+): boolean {
+  const startA = fromA ? toDateOnly(fromA).getTime() : Number.NEGATIVE_INFINITY;
+  const endA = toA ? toDateOnly(toA).getTime() : Number.POSITIVE_INFINITY;
+  const startB = fromB ? toDateOnly(fromB).getTime() : Number.NEGATIVE_INFINITY;
+  const endB = toB ? toDateOnly(toB).getTime() : Number.POSITIVE_INFINITY;
+
+  return startA <= endB && startB <= endA;
+}
+
+function projectSlide(slide: ExclusiveOverlapSlide, update: ExclusiveOverlapUpdate, isAffected: boolean): ExclusiveOverlapSlide {
+  if (!isAffected) {
+    return slide;
+  }
+
+  return {
+    ...slide,
+    dateExclusive: update.dateExclusive ?? slide.dateExclusive,
+    enabled: update.enabled ?? slide.enabled,
+    validFrom: update.validFrom !== undefined ? update.validFrom : slide.validFrom,
+    validTo: update.validTo !== undefined ? update.validTo : slide.validTo,
+  };
+}
+
+export function validateExclusiveOverlap(
+  allSlides: ExclusiveOverlapSlide[],
+  affectedSlideIds: string[],
+  update: ExclusiveOverlapUpdate,
+): { valid: boolean; conflicts: ExclusiveOverlapConflict[] } {
+  const affectedSet = new Set(affectedSlideIds);
+  const projected = allSlides.map((slide) => projectSlide(slide, update, affectedSet.has(slide.id)));
+
+  const exclusiveSlides = projected.filter((slide) => slide.dateExclusive && slide.enabled);
+  const conflicts: ExclusiveOverlapConflict[] = [];
+  const conflictIds = new Set<string>();
+
+  for (let i = 0; i < exclusiveSlides.length; i += 1) {
+    for (let j = i + 1; j < exclusiveSlides.length; j += 1) {
+      const slideA = exclusiveSlides[i];
+      const slideB = exclusiveSlides[j];
+
+      if (!dateRangesOverlap(slideA.validFrom, slideA.validTo, slideB.validFrom, slideB.validTo)) {
+        continue;
+      }
+
+      for (const slide of [slideA, slideB]) {
+        if (!conflictIds.has(slide.id)) {
+          conflictIds.add(slide.id);
+          conflicts.push({
+            slideId: slide.id,
+            label: formatSlideScheduleLabel({ ...slide, weekdays: slide.weekdays ?? [] }),
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    valid: conflicts.length === 0,
+    conflicts,
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "node-html-parser": "8.0.4",
     "nodemailer": "9.0.3",
     "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^6.1.200",
     "pg": "^8.20.0",
     "prop-types": "15.8.1",
     "puppeteer-core": "^25.2.1",

--- a/pages/api/signage/[id].tsx
+++ b/pages/api/signage/[id].tsx
@@ -1,18 +1,52 @@
 import { withHttpMethods } from '@middleware/api/handleMethods';
 import HTTPMethod from 'http-method-enum';
 import prisma from '../../../prisma/prisma';
+import { filterSlidesForDisplay } from '@lib/signage/isSlideActiveNow';
+import { mapSignageFormatView, mapSignageSlide, resolveSignageSlides } from '@lib/signage/signageApiHelpers';
 
 export default withHttpMethods({
   [HTTPMethod.GET]: async (req, res) => {
     const { id } = req.query;
     const { format } = req.query;
+    const includeInactive = req.query.includeInactive === 'true';
 
     const signages = await prisma.signage.findMany({
       where: {
         workspaceId: id as string,
       },
+      include: {
+        slides: {
+          orderBy: {
+            order: 'asc',
+          },
+        },
+      },
     });
-    if (format === undefined) return res.status(200).json({ content: signages });
-    res.status(200).json({ content: signages.find((s) => s.format === format) ?? signages[0] });
+
+    const mappedSignages = signages.map((signage) => ({
+      workspaceId: signage.workspaceId,
+      format: signage.format,
+      backgroundColor: signage.backgroundColor,
+      backgroundMode: signage.backgroundMode,
+      slideDurationSeconds: signage.slideDurationSeconds,
+      mirrorSourceFormat: signage.mirrorSourceFormat,
+      slides: signage.slides.map(mapSignageSlide),
+    }));
+
+    const content = mappedSignages.map((signage) => {
+      const ownSlides = signage.slides;
+      const displaySlides = includeInactive ? ownSlides : filterSlidesForDisplay(resolveSignageSlides(mappedSignages, signage.format));
+
+      return mapSignageFormatView({
+        ...signage,
+        slides: displaySlides,
+      });
+    });
+
+    if (format === undefined) {
+      return res.status(200).json({ content });
+    }
+
+    res.status(200).json({ content: content.find((s) => s.format === format) ?? content[0] });
   },
 });

--- a/pages/api/workspaces/[workspaceId]/admin/backups/backupStructure.ts
+++ b/pages/api/workspaces/[workspaceId]/admin/backups/backupStructure.ts
@@ -18,11 +18,38 @@ import {
   Ingredient,
   IngredientImage,
   IngredientVolume,
+  MonitorFormat,
+  SignageBackgroundMode,
   Unit,
   UnitConversion,
   WorkspaceCocktailRecipeStepAction,
   WorkspaceSetting,
 } from '@generated/prisma/client';
+
+/** Signage container in backups; `content` is legacy pre-slide schema. */
+export interface SignageBackupRecord {
+  workspaceId?: string;
+  format: MonitorFormat;
+  backgroundColor?: string | null;
+  backgroundMode?: SignageBackgroundMode;
+  slideDurationSeconds?: number;
+  mirrorSourceFormat?: MonitorFormat | null;
+  content?: string;
+}
+
+/** Slide in backups; scheduling and mirror fields are optional for older exports. */
+export interface SignageSlideBackupRecord {
+  id?: string;
+  workspaceId?: string;
+  format: MonitorFormat;
+  content: string;
+  order: number;
+  enabled?: boolean;
+  weekdays?: number[];
+  validFrom?: string | Date | null;
+  validTo?: string | Date | null;
+  dateExclusive?: boolean;
+}
 
 export interface BackupStructure {
   units: Unit[];
@@ -48,4 +75,6 @@ export interface BackupStructure {
   calculationGroups: CocktailCalculationGroup[];
   calculationItems: CocktailCalculationItems[];
   ice: Ice[];
+  signage?: SignageBackupRecord[];
+  signageSlides?: SignageSlideBackupRecord[];
 }

--- a/pages/api/workspaces/[workspaceId]/admin/backups/export.tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/backups/export.tsx
@@ -124,12 +124,19 @@ export default withHttpMethods({
           },
         },
       }),
+      signage: await prisma.signage.findMany({ where: { workspaceId } }),
+      signageSlides: await prisma.signageSlide.findMany({
+        where: { workspaceId },
+        orderBy: [{ format: 'asc' }, { order: 'asc' }],
+      }),
     };
 
     console.info(`[BackupExport][${workspaceId}] Export finished`, {
       cocktails: backup.cocktailRecipe.length,
       ingredients: backup.ingredient.length,
       calculations: backup.calculation.length,
+      signage: backup.signage?.length ?? 0,
+      signageSlides: backup.signageSlides?.length ?? 0,
     });
     return res.json(backup);
   }),

--- a/pages/api/workspaces/[workspaceId]/admin/backups/import.tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/backups/import.tsx
@@ -1,9 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { BackupStructure } from './backupStructure';
+import { BackupStructure, SignageBackupRecord, SignageSlideBackupRecord } from './backupStructure';
 import prisma from '../../../../../../prisma/prisma';
 import { randomUUID } from 'crypto';
 import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
-import { Role } from '@generated/prisma/client';
+import { MonitorFormat, Role } from '@generated/prisma/client';
+import { ensureSignageContainer } from '@lib/signage/signageApiHelpers';
 
 const IMPORT_TRANSACTION_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -54,6 +55,40 @@ function convertUnit(unit: string): string {
   }
 }
 
+function parseBackupDate(value: string | Date | null | undefined): Date | null {
+  if (value == null || value === '') {
+    return null;
+  }
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeSignageSlide(slide: SignageSlideBackupRecord, workspaceId: string) {
+  return {
+    id: randomUUID(),
+    workspaceId,
+    format: slide.format,
+    content: slide.content,
+    order: slide.order,
+    enabled: slide.enabled ?? true,
+    weekdays: slide.weekdays ?? [],
+    validFrom: parseBackupDate(slide.validFrom),
+    validTo: parseBackupDate(slide.validTo),
+    dateExclusive: slide.dateExclusive ?? false,
+  };
+}
+
+function normalizeSignageRecord(signage: SignageBackupRecord, workspaceId: string) {
+  return {
+    workspaceId,
+    format: signage.format,
+    backgroundColor: signage.backgroundColor ?? null,
+    backgroundMode: signage.backgroundMode ?? 'COLOR',
+    slideDurationSeconds: signage.slideDurationSeconds ?? 10,
+    mirrorSourceFormat: signage.mirrorSourceFormat ?? null,
+  };
+}
+
 function convertIce(ice: string): string {
   switch (ice) {
     case 'Crushed':
@@ -88,6 +123,8 @@ export default withWorkspacePermission([Role.USER], async (req: NextApiRequest, 
             ingredients: data.ingredient?.length ?? 0,
             cocktails: data.cocktailRecipe?.length ?? 0,
             calculations: data.calculation?.length ?? 0,
+            signage: data.signage?.length ?? 0,
+            signageSlides: data.signageSlides?.length ?? 0,
           });
 
           if (data.workspaceSettings?.length > 0) {
@@ -145,6 +182,7 @@ export default withWorkspacePermission([Role.USER], async (req: NextApiRequest, 
                   },
                 });
                 if (existingUnitConversion == null) {
+                  g.id = randomUUID();
                   g.fromUnitId = newFromId;
                   g.toUnitId = newToId;
                   g.workspaceId = workspaceId;
@@ -592,6 +630,55 @@ export default withWorkspacePermission([Role.USER], async (req: NextApiRequest, 
               g.calculationId = cocktailCalculationMapping.find((gm) => gm.id === g.calculationId)!.newId;
             });
             await transaction.cocktailCalculationItems.createMany({ data: data.calculationItems, skipDuplicates: true });
+          }
+
+          const signageRecords = data.signage ?? [];
+          if (signageRecords.length > 0) {
+            importLogger.step('Importing signage', { count: signageRecords.length });
+            for (const signageRecord of signageRecords) {
+              const normalizedSignage = normalizeSignageRecord(signageRecord, workspaceId);
+              await transaction.signage.upsert({
+                where: {
+                  workspaceId_format: {
+                    workspaceId,
+                    format: signageRecord.format,
+                  },
+                },
+                create: normalizedSignage,
+                update: {
+                  backgroundColor: normalizedSignage.backgroundColor,
+                  backgroundMode: normalizedSignage.backgroundMode,
+                  slideDurationSeconds: normalizedSignage.slideDurationSeconds,
+                  mirrorSourceFormat: normalizedSignage.mirrorSourceFormat,
+                },
+              });
+
+              const legacyContent = signageRecord.content;
+              const hasSlidesForFormat = data.signageSlides?.some((slide) => slide.format === signageRecord.format);
+              if (legacyContent && !hasSlidesForFormat) {
+                await transaction.signageSlide.create({
+                  data: normalizeSignageSlide(
+                    {
+                      format: signageRecord.format,
+                      content: legacyContent,
+                      order: 0,
+                    },
+                    workspaceId,
+                  ),
+                });
+              }
+            }
+          }
+
+          const signageSlideRecords = data.signageSlides ?? [];
+          if (signageSlideRecords.length > 0) {
+            importLogger.step('Importing signage slides', { count: signageSlideRecords.length });
+            for (const slide of signageSlideRecords) {
+              await ensureSignageContainer(transaction, workspaceId, slide.format as MonitorFormat);
+              await transaction.signageSlide.create({
+                data: normalizeSignageSlide(slide, workspaceId),
+              });
+            }
           }
 
           importLogger.step('Import transaction finished');

--- a/pages/api/workspaces/[workspaceId]/admin/signage.tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/signage.tsx
@@ -4,7 +4,91 @@ import { withWorkspacePermission } from '@middleware/api/authenticationMiddlewar
 import { $Enums, Permission, Role } from '@generated/prisma/client';
 import prisma from '../../../../../prisma/prisma';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { SignageSettingsUpdatePayload } from '@lib/signage/types';
+import { parseRequestBody } from '@lib/signage/parseRequestBody';
 import MonitorFormat = $Enums.MonitorFormat;
+
+async function updateSignageFormatSettings(workspaceId: string, format: MonitorFormat, data: SignageSettingsUpdatePayload['landscape']) {
+  if (!data) {
+    return;
+  }
+
+  const existing = await prisma.signage.findUnique({
+    where: {
+      workspaceId_format: {
+        workspaceId,
+        format,
+      },
+    },
+  });
+
+  const mirrorSourceFormat = data.mirrorSourceFormat ?? null;
+
+  const signageData = {
+    slideDurationSeconds: data.slideDurationSeconds,
+    backgroundColor: data.backgroundColor === '' || data.backgroundColor === null ? null : data.backgroundColor,
+    backgroundMode: data.backgroundMode ?? 'COLOR',
+    mirrorSourceFormat,
+  };
+
+  if (existing || data.slides.length > 0 || mirrorSourceFormat) {
+    await prisma.signage.upsert({
+      where: {
+        workspaceId_format: {
+          workspaceId,
+          format,
+        },
+      },
+      update: signageData,
+      create: {
+        workspaceId,
+        format,
+        ...signageData,
+      },
+    });
+  }
+
+  if (mirrorSourceFormat) {
+    await prisma.signageSlide.updateMany({
+      where: {
+        workspaceId,
+        format,
+      },
+      data: {
+        enabled: false,
+      },
+    });
+  } else if (existing?.mirrorSourceFormat) {
+    const formatSlides = await prisma.signageSlide.findMany({
+      where: {
+        workspaceId,
+        format,
+      },
+    });
+
+    if (formatSlides.length === 1 && !formatSlides[0].enabled) {
+      await prisma.signageSlide.update({
+        where: { id: formatSlides[0].id },
+        data: { enabled: true },
+      });
+    }
+  }
+
+  await Promise.all(
+    data.slides.map((slide) =>
+      prisma.signageSlide.updateMany({
+        where: {
+          id: slide.id,
+          workspaceId,
+          format,
+        },
+        data: {
+          order: slide.order,
+        },
+      }),
+    ),
+  );
+}
 
 export default withHttpMethods({
   [HTTPMethod.GET]: withWorkspacePermission([Role.USER], Permission.MONITOR_READ, async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
@@ -17,36 +101,23 @@ export default withHttpMethods({
     return res.status(200).json({ content: signages });
   }),
   [HTTPMethod.PUT]: withWorkspacePermission([Role.MANAGER], Permission.MONITOR_UPDATE, async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
-    const { verticalContent, horizontalContent, verticalBgColor, horizontalBgColor } = JSON.parse(req.body);
+    try {
+      const body = parseRequestBody<SignageSettingsUpdatePayload>(req.body);
 
-    await prisma.signage.deleteMany({
-      where: {
-        workspaceId: workspace.id,
-      },
-    });
-
-    if (verticalContent != undefined && verticalContent != '') {
-      await prisma.signage.create({
-        data: {
-          workspaceId: workspace.id,
-          format: MonitorFormat.PORTRAIT,
-          content: verticalContent,
-          backgroundColor: verticalBgColor == '' ? undefined : verticalBgColor,
-        },
+      await prisma.$transaction(async () => {
+        if (body.landscape) {
+          await updateSignageFormatSettings(workspace.id, MonitorFormat.LANDSCAPE, body.landscape);
+        }
+        if (body.portrait) {
+          await updateSignageFormatSettings(workspace.id, MonitorFormat.PORTRAIT, body.portrait);
+        }
       });
-    }
 
-    if (horizontalContent != undefined && horizontalContent != '') {
-      await prisma.signage.create({
-        data: {
-          workspaceId: workspace.id,
-          format: MonitorFormat.LANDSCAPE,
-          content: horizontalContent,
-          backgroundColor: horizontalBgColor == '' ? undefined : horizontalBgColor,
-        },
-      });
+      return res.status(200).json({ message: 'Signage settings updated' });
+    } catch (error) {
+      console.error('signage PUT', error);
+      const message = error instanceof Error ? error.message : 'Failed to update signage settings';
+      return res.status(500).json({ message });
     }
-
-    res.status(200).json({ message: 'Signage updated' });
   }),
 });

--- a/pages/api/workspaces/[workspaceId]/admin/signage/slides.tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/signage/slides.tsx
@@ -1,7 +1,7 @@
 import HTTPMethod from 'http-method-enum';
 import { withHttpMethods } from '@middleware/api/handleMethods';
 import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
-import { $Enums, Role } from '@generated/prisma/client';
+import { $Enums, Permission, Role } from '@generated/prisma/client';
 import prisma from '../../../../../../prisma/prisma';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { SignageSlideCreatePayload, SignageSlidePatchPayload } from '@lib/signage/types';
@@ -26,7 +26,7 @@ function parseDate(value: string | null | undefined) {
 }
 
 export default withHttpMethods({
-  [HTTPMethod.POST]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+  [HTTPMethod.POST]: withWorkspacePermission([Role.MANAGER], Permission.MONITOR_UPDATE, async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
     const body = parseRequestBody<SignageSlideCreatePayload>(req.body);
 
     if (!body.format || !Array.isArray(body.slides) || body.slides.length === 0) {
@@ -72,7 +72,7 @@ export default withHttpMethods({
     });
   }),
 
-  [HTTPMethod.PATCH]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+  [HTTPMethod.PATCH]: withWorkspacePermission([Role.MANAGER], Permission.MONITOR_UPDATE, async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
     const body = parseRequestBody<SignageSlidePatchPayload>(req.body);
 
     if (!Array.isArray(body.slideIds) || body.slideIds.length === 0) {

--- a/pages/api/workspaces/[workspaceId]/admin/signage/slides.tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/signage/slides.tsx
@@ -1,0 +1,189 @@
+import HTTPMethod from 'http-method-enum';
+import { withHttpMethods } from '@middleware/api/handleMethods';
+import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
+import { $Enums, Role } from '@generated/prisma/client';
+import prisma from '../../../../../../prisma/prisma';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SignageSlideCreatePayload, SignageSlidePatchPayload } from '@lib/signage/types';
+import { ensureSignageContainer, mapSignageSlide } from '@lib/signage/signageApiHelpers';
+import { parseRequestBody } from '@lib/signage/parseRequestBody';
+import { validateExclusiveOverlap } from '@lib/signage/validateExclusiveOverlap';
+import MonitorFormat = $Enums.MonitorFormat;
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '25mb',
+    },
+  },
+};
+
+function parseDate(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  return new Date(value);
+}
+
+export default withHttpMethods({
+  [HTTPMethod.POST]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+    const body = parseRequestBody<SignageSlideCreatePayload>(req.body);
+
+    if (!body.format || !Array.isArray(body.slides) || body.slides.length === 0) {
+      return res.status(400).json({ message: 'Invalid slide upload payload' });
+    }
+
+    const format = body.format as MonitorFormat;
+
+    const createdSlides = await prisma.$transaction(async (tx) => {
+      await ensureSignageContainer(tx, workspace.id, format);
+
+      const maxOrderSlide = await tx.signageSlide.findFirst({
+        where: {
+          workspaceId: workspace.id,
+          format,
+        },
+        orderBy: {
+          order: 'desc',
+        },
+      });
+
+      let nextOrder = (maxOrderSlide?.order ?? -1) + 1;
+      const created = [];
+
+      for (const content of body.slides) {
+        const slide = await tx.signageSlide.create({
+          data: {
+            workspaceId: workspace.id,
+            format,
+            content,
+            order: nextOrder,
+          },
+        });
+        created.push(slide);
+        nextOrder += 1;
+      }
+
+      return created;
+    });
+
+    res.status(201).json({
+      slides: createdSlides.map(mapSignageSlide),
+    });
+  }),
+
+  [HTTPMethod.PATCH]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+    const body = parseRequestBody<SignageSlidePatchPayload>(req.body);
+
+    if (!Array.isArray(body.slideIds) || body.slideIds.length === 0) {
+      return res.status(400).json({ message: 'No slide ids provided' });
+    }
+
+    const existingSlides = await prisma.signageSlide.findMany({
+      where: {
+        workspaceId: workspace.id,
+        id: {
+          in: body.slideIds,
+        },
+      },
+    });
+
+    if (existingSlides.length === 0) {
+      return res.status(404).json({ message: 'Slides not found' });
+    }
+
+    const format = existingSlides[0].format;
+    const allFormatSlides = await prisma.signageSlide.findMany({
+      where: {
+        workspaceId: workspace.id,
+        format,
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    });
+
+    const scheduleFieldsChanging = body.dateExclusive !== undefined || body.validFrom !== undefined || body.validTo !== undefined || body.enabled !== undefined;
+
+    if (scheduleFieldsChanging) {
+      const validation = validateExclusiveOverlap(
+        allFormatSlides.map((slide) => ({
+          id: slide.id,
+          dateExclusive: slide.dateExclusive,
+          enabled: slide.enabled,
+          validFrom: slide.validFrom,
+          validTo: slide.validTo,
+          weekdays: slide.weekdays,
+        })),
+        body.slideIds,
+        {
+          dateExclusive: body.dateExclusive,
+          enabled: body.enabled,
+          validFrom: body.validFrom,
+          validTo: body.validTo,
+        },
+      );
+
+      if (!validation.valid) {
+        return res.status(409).json({
+          message: 'Exklusive Zeiträume überschneiden sich mit bestehenden exklusiven Karten',
+          conflicts: validation.conflicts,
+        });
+      }
+    }
+
+    const data: {
+      enabled?: boolean;
+      weekdays?: number[];
+      validFrom?: Date | null;
+      validTo?: Date | null;
+      dateExclusive?: boolean;
+    } = {};
+
+    if (body.enabled !== undefined) {
+      data.enabled = body.enabled;
+    }
+    if (body.weekdays !== undefined) {
+      data.weekdays = body.weekdays;
+    }
+    if (body.validFrom !== undefined) {
+      data.validFrom = parseDate(body.validFrom);
+    }
+    if (body.validTo !== undefined) {
+      data.validTo = parseDate(body.validTo);
+    }
+    if (body.dateExclusive !== undefined) {
+      data.dateExclusive = body.dateExclusive;
+    }
+
+    if (Object.keys(data).length === 0) {
+      return res.status(400).json({ message: 'No update fields provided' });
+    }
+
+    await prisma.signageSlide.updateMany({
+      where: {
+        workspaceId: workspace.id,
+        id: {
+          in: body.slideIds,
+        },
+      },
+      data,
+    });
+
+    const slides = await prisma.signageSlide.findMany({
+      where: {
+        workspaceId: workspace.id,
+        id: {
+          in: body.slideIds,
+        },
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    });
+
+    res.status(200).json({
+      slides: slides.map(mapSignageSlide),
+    });
+  }),
+});

--- a/pages/api/workspaces/[workspaceId]/admin/signage/slides/[slideId].tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/signage/slides/[slideId].tsx
@@ -1,29 +1,33 @@
 import HTTPMethod from 'http-method-enum';
 import { withHttpMethods } from '@middleware/api/handleMethods';
 import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
-import { Role } from '@generated/prisma/client';
+import { Permission, Role } from '@generated/prisma/client';
 import prisma from '../../../../../../../prisma/prisma';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default withHttpMethods({
-  [HTTPMethod.DELETE]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
-    const { slideId } = req.query;
+  [HTTPMethod.DELETE]: withWorkspacePermission(
+    [Role.MANAGER],
+    Permission.MONITOR_UPDATE,
+    async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+      const { slideId } = req.query;
 
-    if (!slideId || typeof slideId !== 'string') {
-      return res.status(400).json({ message: 'Slide id is required' });
-    }
+      if (!slideId || typeof slideId !== 'string') {
+        return res.status(400).json({ message: 'Slide id is required' });
+      }
 
-    const result = await prisma.signageSlide.deleteMany({
-      where: {
-        id: slideId,
-        workspaceId: workspace.id,
-      },
-    });
+      const result = await prisma.signageSlide.deleteMany({
+        where: {
+          id: slideId,
+          workspaceId: workspace.id,
+        },
+      });
 
-    if (result.count === 0) {
-      return res.status(404).json({ message: 'Slide not found' });
-    }
+      if (result.count === 0) {
+        return res.status(404).json({ message: 'Slide not found' });
+      }
 
-    res.status(200).json({ message: 'Slide deleted' });
-  }),
+      res.status(200).json({ message: 'Slide deleted' });
+    },
+  ),
 });

--- a/pages/api/workspaces/[workspaceId]/admin/signage/slides/[slideId].tsx
+++ b/pages/api/workspaces/[workspaceId]/admin/signage/slides/[slideId].tsx
@@ -1,0 +1,29 @@
+import HTTPMethod from 'http-method-enum';
+import { withHttpMethods } from '@middleware/api/handleMethods';
+import { withWorkspacePermission } from '@middleware/api/authenticationMiddleware';
+import { Role } from '@generated/prisma/client';
+import prisma from '../../../../../../../prisma/prisma';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default withHttpMethods({
+  [HTTPMethod.DELETE]: withWorkspacePermission([Role.MANAGER], async (req: NextApiRequest, res: NextApiResponse, user, workspace) => {
+    const { slideId } = req.query;
+
+    if (!slideId || typeof slideId !== 'string') {
+      return res.status(400).json({ message: 'Slide id is required' });
+    }
+
+    const result = await prisma.signageSlide.deleteMany({
+      where: {
+        id: slideId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    if (result.count === 0) {
+      return res.status(404).json({ message: 'Slide not found' });
+    }
+
+    res.status(200).json({ message: 'Slide deleted' });
+  }),
+});

--- a/pages/signage.tsx
+++ b/pages/signage.tsx
@@ -1,57 +1,102 @@
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { alertService } from '@lib/alertService';
-import { $Enums, Signage } from '@generated/prisma/client';
+import { $Enums } from '@generated/prisma/client';
 import { PageCenter } from '@components/layout/PageCenter';
 import { Loading } from '@components/Loading';
-import Image from 'next/image';
+import { SignageSlideDisplay } from '@components/signage/SignageSlideDisplay';
+import { SignageFormatView } from '@lib/signage/types';
+import { filterSlidesForDisplay } from '@lib/signage/isSlideActiveNow';
+import { getSignageContainerClassName, getSignageContainerStyle } from '@lib/signage/signageBackground';
+import { cn } from '@components/ui';
 import MonitorFormat = $Enums.MonitorFormat;
 
-export default function SignagePage() {
-  const format: MonitorFormat =
-    typeof window !== 'undefined' && window.matchMedia('(orientation: portrait)').matches ? MonitorFormat.PORTRAIT : MonitorFormat.LANDSCAPE;
-  const router = useRouter();
+function getMonitorFormat(): MonitorFormat {
+  if (typeof window === 'undefined') {
+    return MonitorFormat.LANDSCAPE;
+  }
 
+  return window.matchMedia('(orientation: portrait)').matches ? MonitorFormat.PORTRAIT : MonitorFormat.LANDSCAPE;
+}
+
+function subscribeToOrientation(onStoreChange: () => void) {
+  const mediaQuery = window.matchMedia('(orientation: portrait)');
+  mediaQuery.addEventListener('change', onStoreChange);
+  return () => mediaQuery.removeEventListener('change', onStoreChange);
+}
+
+export default function SignagePage() {
+  const router = useRouter();
   const { id } = router.query;
 
-  const [content, setContent] = useState<Signage>();
+  const format = useSyncExternalStore(subscribeToOrientation, getMonitorFormat, () => MonitorFormat.LANDSCAPE);
+  const [content, setContent] = useState<SignageFormatView>();
   const [imageLoading, setImageLoading] = useState<boolean>(false);
 
-  const fetchData = useCallback(() => {
-    if (!id) return;
-    setImageLoading(true);
-    fetch(`/api/signage/${id}?format=${format}`)
-      .then((response) => response.json())
-      .then((data) => {
-        setContent(data.content);
-        setImageLoading(false);
-      })
-      .catch((error) => {
-        console.error('Signage', error);
-        alertService.error('Fehler beim Laden der Karte.');
-      })
-      .finally(() => {
-        setImageLoading(false);
-      });
-  }, [id, format]);
+  const fetchData = useCallback(
+    (options?: { silent?: boolean }) => {
+      if (!id) return;
+      if (!options?.silent) {
+        setImageLoading(true);
+      }
+      fetch(`/api/signage/${id}?format=${format}`)
+        .then((response) => response.json())
+        .then((data) => {
+          setContent(data.content);
+        })
+        .catch((error) => {
+          console.error('Signage', error);
+          if (!options?.silent) {
+            alertService.error('Fehler beim Laden der Karte.');
+          }
+        })
+        .finally(() => {
+          if (!options?.silent) {
+            setImageLoading(false);
+          }
+        });
+    },
+    [id, format],
+  );
 
   useEffect(() => {
-    if (!imageLoading && !content) {
-      fetchData();
-    }
-  }, [content, fetchData, imageLoading]);
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const interval = window.setInterval(
+      () => {
+        fetchData({ silent: true });
+      },
+      5 * 60 * 1000,
+    );
+
+    return () => window.clearInterval(interval);
+  }, [id, fetchData]);
+
+  const slides = useMemo(() => filterSlidesForDisplay(content?.slides ?? []), [content?.slides]);
+  const backgroundMode = content?.backgroundMode ?? 'COLOR';
 
   return (
-    <div style={content?.backgroundColor ? { backgroundColor: content.backgroundColor } : {}} className={'h-screen w-screen'}>
-      <PageCenter>
-        {imageLoading ? (
+    <div
+      className={cn('relative h-screen w-screen', getSignageContainerClassName(backgroundMode, content?.backgroundColor, { external: true }))}
+      style={getSignageContainerStyle(backgroundMode, content?.backgroundColor)}
+    >
+      {imageLoading ? (
+        <PageCenter>
           <Loading />
-        ) : content?.content ? (
-          <Image src={content.content} layout={'fill'} objectFit={'contain'} alt={'Horizontal monitor'} />
-        ) : (
-          <div>Keine Karte gefunden</div>
-        )}
-      </PageCenter>
+        </PageCenter>
+      ) : (
+        <SignageSlideDisplay
+          slides={slides}
+          slideDurationSeconds={content?.slideDurationSeconds ?? 10}
+          backgroundMode={backgroundMode}
+          emptyMessage="Keine Karte gefunden"
+          alt="Monitor slide"
+        />
+      )}
     </div>
   );
 }

--- a/pages/workspaces/[workspaceId]/manage/monitor/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/monitor/index.tsx
@@ -681,4 +681,4 @@ const ManageMonitorPage: NextPageWithPullToRefresh = () => {
   );
 };
 
-export default withPagePermission(['MANAGER'], ManageMonitorPage, '/workspaces/[workspaceId]/manage');
+export default withPagePermission([Role.MANAGER], ManageMonitorPage, '/workspaces/[workspaceId]/manage');

--- a/pages/workspaces/[workspaceId]/manage/monitor/index.tsx
+++ b/pages/workspaces/[workspaceId]/manage/monitor/index.tsx
@@ -1,83 +1,488 @@
 import { ManageEntityLayout } from '@components/layout/ManageEntityLayout';
 import { useRouter } from 'next/router';
-import { $Enums, Role, Signage } from '@generated/prisma/client';
+import { $Enums, Role } from '@generated/prisma/client';
 import { alertService } from '@lib/alertService';
-import { FaShareAlt, FaTrashAlt } from 'react-icons/fa';
+import { FaShareAlt } from 'react-icons/fa';
 import { UploadDropZone } from '@components/UploadDropZone';
-import { compressFile } from '@lib/ImageCompressor';
-import { convertToBase64 } from '@lib/Base64Converter';
-import { DeleteConfirmationModal } from '@components/modals/DeleteConfirmationModal';
-import Image from 'next/image';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { ModalContext } from '@lib/context/ModalContextProvider';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { UserContext } from '@lib/context/UserContextProvider';
 import { withPagePermission } from '@middleware/ui/withPagePermission';
 import { NextPageWithPullToRefresh } from '../../../../../types/next';
 import MonitorFormat = $Enums.MonitorFormat;
-import { Button, Card, CardBody, CardTitle, FormControl, Input, Label, LabelText, Loading as UiLoading } from '@components/ui';
+import { Button, Card, CardBody, CardTitle, Checkbox, FormControl, Input, Label, LabelText, Loading as UiLoading, Radio } from '@components/ui';
+import { SignageSlideList } from '@components/signage/SignageSlideList';
+import {
+  ExclusiveConflict,
+  SignageBackgroundMode,
+  SignageFormatView,
+  SignageSettingsUpdatePayload,
+  SignageSlideFilterState,
+  SignageSlideView,
+} from '@lib/signage/types';
+import { processSignageFiles } from '@lib/signage/processSignageFiles';
+import { SignageSlideBulkActions } from '@components/signage/SignageSlideBulkActions';
+import { SignageSlideFilter } from '@components/signage/SignageSlideFilter';
+import { SignageMonitorPreview } from '@components/signage/SignageMonitorPreview';
+import { filterSlidesForAdmin } from '@lib/signage/filterSlidesForAdmin';
+
+interface SignageFormatState {
+  slides: SignageSlideView[];
+  backgroundColor?: string | null;
+  backgroundMode: SignageBackgroundMode;
+  slideDurationSeconds: number;
+  mirrorSourceFormat?: MonitorFormat | null;
+}
+
+const defaultFormatState = (): SignageFormatState => ({
+  slides: [],
+  backgroundColor: undefined,
+  backgroundMode: 'COLOR',
+  slideDurationSeconds: 10,
+  mirrorSourceFormat: null,
+});
+
+const defaultFilterState = (): SignageSlideFilterState => ({
+  mode: 'all',
+});
+
+function formatLabel(format: MonitorFormat): string {
+  return format === MonitorFormat.LANDSCAPE ? 'Horizontal' : 'Vertikal';
+}
+
+function otherFormat(format: MonitorFormat): MonitorFormat {
+  return format === MonitorFormat.LANDSCAPE ? MonitorFormat.PORTRAIT : MonitorFormat.LANDSCAPE;
+}
+
+function formatPayloadKey(format: MonitorFormat): 'landscape' | 'portrait' {
+  return format === MonitorFormat.LANDSCAPE ? 'landscape' : 'portrait';
+}
+
+class SignagePatchError extends Error {
+  conflicts?: ExclusiveConflict[];
+
+  constructor(message: string, conflicts?: ExclusiveConflict[]) {
+    super(message);
+    this.conflicts = conflicts;
+  }
+}
+
+async function patchSlides(
+  workspaceId: string,
+  payload: {
+    slideIds: string[];
+    enabled?: boolean;
+    weekdays?: number[];
+    validFrom?: string | null;
+    validTo?: string | null;
+    dateExclusive?: boolean;
+  },
+) {
+  const response = await fetch(`/api/workspaces/${workspaceId}/admin/signage/slides`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await response.json();
+  if (!response.ok) {
+    throw new SignagePatchError(body.message ?? 'Fehler beim Aktualisieren der Slides', body.conflicts);
+  }
+
+  return body.slides as SignageSlideView[];
+}
+
+async function parseJsonResponseBody(response: Response): Promise<{ message?: string }> {
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as { message?: string };
+  } catch {
+    if (!response.ok) {
+      throw new Error(`Serverfehler (${response.status})`);
+    }
+    return {};
+  }
+}
+
+async function putSignageSettings(workspaceId: string, payload: SignageSettingsUpdatePayload) {
+  const response = await fetch(`/api/workspaces/${workspaceId}/admin/signage`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await parseJsonResponseBody(response);
+  if (!response.ok) {
+    throw new Error(body.message ?? 'Fehler beim Speichern');
+  }
+}
+
+function buildFormatPayload(state: SignageFormatState): SignageSettingsUpdatePayload['landscape'] {
+  return {
+    slides: state.slides.map((slide, order) => ({ id: slide.id, order })),
+    backgroundColor: state.backgroundColor ?? null,
+    backgroundMode: state.backgroundMode,
+    slideDurationSeconds: state.slideDurationSeconds,
+    mirrorSourceFormat: state.mirrorSourceFormat ?? null,
+  };
+}
+
+function SignageFormatEditor({
+  title,
+  workspaceId,
+  format,
+  state,
+  sourceSlides,
+  uploading,
+  selectedIds,
+  filter,
+  onStateChange,
+  onFilesSelected,
+  onToggleSelect,
+  onToggleSelectAll,
+  onFilterChange,
+  onClearSelection,
+  onMirrorChange,
+}: {
+  title: string;
+  workspaceId: string;
+  format: MonitorFormat;
+  state: SignageFormatState;
+  sourceSlides: SignageSlideView[];
+  uploading: boolean;
+  selectedIds: Set<string>;
+  filter: SignageSlideFilterState;
+  onStateChange: (state: SignageFormatState) => void;
+  onFilesSelected: (files: File[]) => Promise<void>;
+  onToggleSelect: (slideId: string) => void;
+  onToggleSelectAll: (slideIds: string[]) => void;
+  onFilterChange: (filter: SignageSlideFilterState) => void;
+  onClearSelection: () => void;
+  onMirrorChange: (mirrorSourceFormat: MonitorFormat | null) => Promise<void>;
+}) {
+  const isMirroring = Boolean(state.mirrorSourceFormat);
+  const filteredSlides = useMemo(() => filterSlidesForAdmin(state.slides, filter), [state.slides, filter]);
+  const previewSlides = isMirroring ? sourceSlides : state.slides;
+  const formatView: SignageFormatView = {
+    workspaceId,
+    format,
+    backgroundColor: state.backgroundColor ?? null,
+    backgroundMode: state.backgroundMode,
+    slideDurationSeconds: state.slideDurationSeconds,
+    mirrorSourceFormat: state.mirrorSourceFormat ?? null,
+    slides: previewSlides,
+  };
+
+  const updateSlidesInState = (updatedSlides: SignageSlideView[]) => {
+    const byId = new Map(updatedSlides.map((slide) => [slide.id, slide]));
+    onStateChange({
+      ...state,
+      slides: state.slides.map((slide) => byId.get(slide.id) ?? slide),
+    });
+  };
+
+  const handlePatchError = (error: unknown) => {
+    if (error instanceof SignagePatchError) {
+      const conflictLabels = error.conflicts?.map((conflict) => conflict.label).join(', ');
+      alertService.error(
+        conflictLabels ? `Exklusive Zeiträume überschneiden sich: ${conflictLabels}` : (error.message ?? 'Exklusive Zeiträume überschneiden sich'),
+      );
+      return;
+    }
+    alertService.error('Fehler beim Aktualisieren der Slides');
+  };
+
+  const handleToggleEnabled = async (slideId: string, enabled: boolean) => {
+    try {
+      const updated = await patchSlides(workspaceId, { slideIds: [slideId], enabled });
+      updateSlidesInState(updated);
+    } catch (error) {
+      handlePatchError(error);
+    }
+  };
+
+  const handleDelete = async (slideId: string) => {
+    const response = await fetch(`/api/workspaces/${workspaceId}/admin/signage/slides/${slideId}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) {
+      const body = await response.json();
+      alertService.error(body.message ?? 'Fehler beim Löschen');
+      return;
+    }
+    onStateChange({
+      ...state,
+      slides: state.slides.filter((slide) => slide.id !== slideId),
+    });
+    onClearSelection();
+  };
+
+  const handleBulkApply = async (payload: { weekdays: number[]; validFrom: string | null; validTo: string | null; dateExclusive: boolean }) => {
+    try {
+      const updated = await patchSlides(workspaceId, {
+        slideIds: Array.from(selectedIds),
+        weekdays: payload.weekdays,
+        validFrom: payload.validFrom,
+        validTo: payload.validTo,
+        dateExclusive: payload.dateExclusive,
+      });
+      updateSlidesInState(updated);
+      alertService.success('Zeitplan aktualisiert');
+    } catch (error) {
+      handlePatchError(error);
+    }
+  };
+
+  const handleSlideScheduleApply = async (
+    slideId: string,
+    payload: { weekdays: number[]; validFrom: string | null; validTo: string | null; dateExclusive: boolean },
+  ) => {
+    try {
+      const updated = await patchSlides(workspaceId, {
+        slideIds: [slideId],
+        weekdays: payload.weekdays,
+        validFrom: payload.validFrom,
+        validTo: payload.validTo,
+        dateExclusive: payload.dateExclusive,
+      });
+      updateSlidesInState(updated);
+      alertService.success('Zeitplan aktualisiert');
+    } catch (error) {
+      handlePatchError(error);
+      throw error;
+    }
+  };
+
+  const handleBulkEnable = async (enabled: boolean) => {
+    try {
+      const updated = await patchSlides(workspaceId, {
+        slideIds: Array.from(selectedIds),
+        enabled,
+      });
+      updateSlidesInState(updated);
+      alertService.success(enabled ? 'Slides aktiviert' : 'Slides deaktiviert');
+    } catch (error) {
+      handlePatchError(error);
+    }
+  };
+
+  const sourceLabel = formatLabel(otherFormat(format));
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="font-medium">{title}</div>
+
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox checked={isMirroring} onChange={() => onMirrorChange(isMirroring ? null : otherFormat(format))} />
+        <span>Gleiche Inhalte wie {sourceLabel} anzeigen (Bild wird automatisch angepasst)</span>
+      </label>
+
+      {isMirroring ? (
+        <div className="rounded-lg border border-base-300/60 bg-base-200/40 p-3 text-sm text-base-content/70">
+          Inhalte werden von {sourceLabel} übernommen. Eigene Slides bleiben gespeichert, sind aber deaktiviert.
+        </div>
+      ) : (
+        <>
+          <UploadDropZone
+            multiple
+            accept="image/*,application/pdf"
+            label="Dateien wählen"
+            hint="(z.B. PNG, JPG, GIF oder PDF)"
+            maxUploadSize={'1MB pro Bild'}
+            onSelectedFilesChanged={() => undefined}
+            onFilesSelected={onFilesSelected}
+          />
+          {uploading ? (
+            <div className="flex items-center gap-2 text-sm text-base-content/70">
+              <UiLoading size="sm" />
+              Dateien werden hochgeladen...
+            </div>
+          ) : null}
+
+          <SignageSlideFilter value={filter} onChange={onFilterChange} />
+
+          <SignageSlideBulkActions
+            selectedCount={selectedIds.size}
+            onApply={handleBulkApply}
+            onDisable={() => handleBulkEnable(false)}
+            onEnable={() => handleBulkEnable(true)}
+            onClearSelection={onClearSelection}
+          />
+
+          <SignageSlideList
+            slides={filteredSlides}
+            selectedIds={selectedIds}
+            onChange={(slides) => {
+              const filteredIds = new Set(filteredSlides.map((slide) => slide.id));
+              const reorderedVisible = slides;
+              const hiddenSlides = state.slides.filter((slide) => !filteredIds.has(slide.id));
+              onStateChange({
+                ...state,
+                slides: [...reorderedVisible, ...hiddenSlides].map((slide, index) => ({ ...slide, order: index })),
+              });
+            }}
+            onToggleSelect={onToggleSelect}
+            onToggleSelectAll={() => onToggleSelectAll(filteredSlides.map((slide) => slide.id))}
+            onToggleEnabled={handleToggleEnabled}
+            onDelete={handleDelete}
+            onScheduleApply={handleSlideScheduleApply}
+          />
+        </>
+      )}
+
+      <FormControl>
+        <Label>
+          <LabelText>Anzeigedauer pro Slide (Sekunden)</LabelText>
+        </Label>
+        <Input
+          type="number"
+          min={1}
+          max={300}
+          disabled={!isMirroring && state.slides.length === 0}
+          value={state.slideDurationSeconds}
+          onChange={(event) =>
+            onStateChange({
+              ...state,
+              slideDurationSeconds: Math.max(1, Number(event.target.value) || 10),
+            })
+          }
+        />
+      </FormControl>
+      <FormControl>
+        <Label>
+          <LabelText>Hintergrund</LabelText>
+        </Label>
+        <div className="flex flex-col gap-2">
+          <Label className="flex-row items-center gap-2">
+            <Radio
+              name={`background-mode-${format}`}
+              value="COLOR"
+              checked={state.backgroundMode === 'COLOR'}
+              disabled={!isMirroring && state.slides.length === 0}
+              onChange={() => onStateChange({ ...state, backgroundMode: 'COLOR' })}
+            />
+            <LabelText>Farbe</LabelText>
+          </Label>
+          <Label className="flex-row items-center gap-2">
+            <Radio
+              name={`background-mode-${format}`}
+              value="BLURRED"
+              checked={state.backgroundMode === 'BLURRED'}
+              disabled={!isMirroring && state.slides.length === 0}
+              onChange={() => onStateChange({ ...state, backgroundMode: 'BLURRED' })}
+            />
+            <LabelText>Unscharfer Hintergrund</LabelText>
+          </Label>
+        </div>
+      </FormControl>
+      {state.backgroundMode === 'COLOR' ? (
+        <FormControl>
+          <Label>
+            <LabelText>Hintergrundfarbe</LabelText>
+          </Label>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <div className="relative h-11 w-full min-w-32 overflow-hidden rounded-lg border border-base-300 sm:w-32">
+              <Input
+                type="color"
+                disabled={!isMirroring && state.slides.length === 0}
+                value={state.backgroundColor ?? '#000000'}
+                onChange={(event) => onStateChange({ ...state, backgroundColor: event.target.value })}
+                bordered={false}
+                className="absolute inset-0 h-full min-h-0 w-full cursor-pointer border-0 bg-transparent p-0 [&::-webkit-color-swatch]:border-0 [&::-webkit-color-swatch-wrapper]:p-0"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={(!isMirroring && state.slides.length === 0) || state.backgroundColor == null}
+              onClick={() => onStateChange({ ...state, backgroundColor: null })}
+            >
+              Farbe entfernen
+            </Button>
+          </div>
+        </FormControl>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <div className="text-sm font-medium">Live-Vorschau</div>
+        <SignageMonitorPreview format={formatView} />
+      </div>
+    </div>
+  );
+}
 
 const ManageMonitorPage: NextPageWithPullToRefresh = () => {
   const router = useRouter();
   const { workspaceId } = router.query;
-  const modalContext = useContext(ModalContext);
   const userContext = useContext(UserContext);
 
   const [signageLoading, setSignageLoading] = useState<boolean>(true);
-
-  const [verticalImage, setVerticalImage] = useState<string>();
-  const [verticalImageColor, setVerticalImageColor] = useState<string>();
-  const [horizontalImage, setHorizontalImage] = useState<string>();
-  const [horizontalImageColor, setHorizontalImageColor] = useState<string>();
+  const [landscape, setLandscape] = useState<SignageFormatState>(defaultFormatState);
+  const [portrait, setPortrait] = useState<SignageFormatState>(defaultFormatState);
   const [updatingSignage, setUpdatingSignage] = useState<boolean>(false);
-
+  const [landscapeUploading, setLandscapeUploading] = useState(false);
+  const [portraitUploading, setPortraitUploading] = useState(false);
   const [copyToClipboardLoading, setCopyToClipboardLoading] = useState<boolean>(false);
+  const [landscapeSelectedIds, setLandscapeSelectedIds] = useState<Set<string>>(new Set());
+  const [portraitSelectedIds, setPortraitSelectedIds] = useState<Set<string>>(new Set());
+  const [landscapeFilter, setLandscapeFilter] = useState<SignageSlideFilterState>(defaultFilterState);
+  const [portraitFilter, setPortraitFilter] = useState<SignageSlideFilterState>(defaultFilterState);
 
   const handleUpdateSignage = useCallback(async () => {
+    if (!workspaceId) return;
     setUpdatingSignage(true);
-    fetch(`/api/workspaces/${workspaceId}/admin/signage`, {
-      method: 'PUT',
-      body: JSON.stringify({
-        verticalContent: verticalImage,
-        horizontalContent: horizontalImage,
-        verticalBgColor: verticalImageColor,
-        horizontalBgColor: horizontalImageColor,
-      }),
-    })
-      .then(async (response) => {
-        const body = await response.json();
-        if (response.ok) {
-          alertService.success(`Update erfolgreich`);
-        } else {
-          console.error('Admin -> UpdateSignage', response);
-          alertService.error(body.message ?? 'Fehler beim Speichern', response.status, response.statusText);
-        }
-      })
-      .catch((error) => {
-        console.error('SettingsPage -> handleUpdateSignage', error);
-        alertService.error('Es ist ein Fehler Aufgetreten, z.B. zu große Datei');
-      })
-      .finally(() => {
-        setUpdatingSignage(false);
-      });
-  }, [horizontalImage, horizontalImageColor, verticalImage, verticalImageColor, workspaceId]);
+
+    const payload: SignageSettingsUpdatePayload = {
+      landscape: buildFormatPayload(landscape),
+      portrait: buildFormatPayload(portrait),
+    };
+
+    try {
+      await putSignageSettings(workspaceId as string, payload);
+      alertService.success('Reihenfolge und Anzeigedauer gespeichert');
+    } catch (error) {
+      console.error('SettingsPage -> handleUpdateSignage', error);
+      alertService.error(error instanceof Error ? error.message : 'Es ist ein Fehler aufgetreten');
+    } finally {
+      setUpdatingSignage(false);
+    }
+  }, [landscape, portrait, workspaceId]);
 
   const fetchSignage = useCallback(() => {
     if (workspaceId == undefined) return;
     setSignageLoading(true);
-    fetch(`/api/signage/${workspaceId}`)
-      .then(async (response) => {
-        return response.json();
-      })
+    fetch(`/api/signage/${workspaceId}?includeInactive=true`)
+      .then(async (response) => response.json())
       .then((data) => {
-        data.content.forEach((signage: Signage) => {
-          if (signage.format == MonitorFormat.PORTRAIT) {
-            setVerticalImage(signage.content);
-            setVerticalImageColor(signage.backgroundColor ?? undefined);
+        const nextLandscape = defaultFormatState();
+        const nextPortrait = defaultFormatState();
+
+        data.content.forEach((signage: SignageFormatView) => {
+          const formatState: SignageFormatState = {
+            slides: signage.slides,
+            backgroundColor: signage.backgroundColor ?? null,
+            backgroundMode: signage.backgroundMode ?? 'COLOR',
+            slideDurationSeconds: signage.slideDurationSeconds,
+            mirrorSourceFormat: signage.mirrorSourceFormat ?? null,
+          };
+
+          if (signage.format === MonitorFormat.PORTRAIT) {
+            Object.assign(nextPortrait, formatState);
           } else {
-            setHorizontalImage(signage.content);
-            setHorizontalImageColor(signage.backgroundColor ?? undefined);
+            Object.assign(nextLandscape, formatState);
           }
         });
+
+        setLandscape(nextLandscape);
+        setPortrait(nextPortrait);
       })
       .catch((error) => {
         console.error('SettingsPage -> fetchSignage', error);
@@ -96,9 +501,111 @@ const ManageMonitorPage: NextPageWithPullToRefresh = () => {
     fetchSignage();
   };
 
+  const uploadSlides = async (
+    files: File[],
+    format: MonitorFormat,
+    setUploading: (value: boolean) => void,
+    setState: React.Dispatch<React.SetStateAction<SignageFormatState>>,
+  ) => {
+    if (!workspaceId) return;
+    setUploading(true);
+    try {
+      const processedSlides = await processSignageFiles(files);
+      if (processedSlides.length === 0) {
+        return;
+      }
+
+      const response = await fetch(`/api/workspaces/${workspaceId}/admin/signage/slides`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          format,
+          slides: processedSlides,
+        }),
+      });
+
+      const body = await response.json();
+      if (!response.ok) {
+        alertService.error(body.message ?? 'Fehler beim Hochladen');
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        slides: [...current.slides, ...body.slides],
+      }));
+      alertService.success('Upload erfolgreich');
+    } catch (error) {
+      console.error('uploadSlides', error);
+      alertService.error('Fehler beim Hochladen');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleMirrorChange = async (
+    format: MonitorFormat,
+    state: SignageFormatState,
+    setState: React.Dispatch<React.SetStateAction<SignageFormatState>>,
+    mirrorSourceFormat: MonitorFormat | null,
+  ) => {
+    if (!workspaceId) return;
+
+    const nextState: SignageFormatState = {
+      ...state,
+      mirrorSourceFormat,
+      slides: mirrorSourceFormat
+        ? state.slides.map((slide) => ({ ...slide, enabled: false }))
+        : state.slides.length === 1 && !state.slides[0].enabled
+          ? [{ ...state.slides[0], enabled: true }]
+          : state.slides,
+    };
+
+    const payload: SignageSettingsUpdatePayload = {
+      [formatPayloadKey(format)]: {
+        ...buildFormatPayload(nextState),
+        mirrorSourceFormat,
+      },
+    };
+
+    try {
+      await putSignageSettings(workspaceId as string, payload);
+      setState(nextState);
+      alertService.success(mirrorSourceFormat ? `Spiegelung von ${formatLabel(mirrorSourceFormat)} aktiviert` : 'Spiegelung deaktiviert');
+    } catch (error) {
+      console.error('handleMirrorChange', error);
+      alertService.error(error instanceof Error ? error.message : 'Fehler beim Speichern der Spiegelung');
+    }
+  };
+
+  const toggleSelection = (setter: React.Dispatch<React.SetStateAction<Set<string>>>, slideId: string) => {
+    setter((current) => {
+      const next = new Set(current);
+      if (next.has(slideId)) {
+        next.delete(slideId);
+      } else {
+        next.add(slideId);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = (setter: React.Dispatch<React.SetStateAction<Set<string>>>, slideIds: string[]) => {
+    setter((current) => {
+      const allSelected = slideIds.every((id) => current.has(id));
+      if (allSelected) {
+        const next = new Set(current);
+        slideIds.forEach((id) => next.delete(id));
+        return next;
+      }
+      return new Set([...current, ...slideIds]);
+    });
+  };
+
   return (
     <ManageEntityLayout title={'Monitor'} backLink={`/workspaces/${workspaceId}/manage`}>
-      {/*Signage*/}
       {userContext.isUserPermitted(Role.MANAGER) ? (
         <Card>
           <CardBody>
@@ -120,146 +627,56 @@ const ManageMonitorPage: NextPageWithPullToRefresh = () => {
                 <FaShareAlt /> Link kopieren
               </Button>
             </CardTitle>
-            <div className={'grid grid-cols-2 gap-2'}>
-              <div className={'flex flex-col gap-2'}>
-                <div>Horizontal</div>
-                {signageLoading ? (
-                  <div className={'justify-center-center flex w-full flex-col items-center gap-2'}>
-                    <UiLoading />
-                    <div>Lade Einstellungen...</div>
-                  </div>
-                ) : (
-                  <>
-                    {horizontalImage == undefined ? (
-                      <UploadDropZone
-                        maxUploadSize={'1MB'}
-                        onSelectedFilesChanged={async (file) => {
-                          if (file) {
-                            const compressedImageFile = await compressFile(file);
-                            const base = await convertToBase64(compressedImageFile);
-                            setHorizontalImage(base);
-                          } else {
-                            alertService.error('Datei konnte nicht ausgewählt werden.');
-                          }
-                        }}
-                      />
-                    ) : (
-                      <div className={'relative h-full min-h-40'}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          shape="square"
-                          size="sm"
-                          className="absolute top-2 right-2 z-10 border-error text-error hover:bg-error/10"
-                          onClick={() =>
-                            modalContext.openModal(
-                              <DeleteConfirmationModal spelling={'REMOVE'} entityName={'das Bild'} onApprove={async () => setHorizontalImage(undefined)} />,
-                            )
-                          }
-                        >
-                          <FaTrashAlt />
-                        </Button>
-                        <Image
-                          className={'w-fit rounded-lg'}
-                          src={horizontalImage}
-                          layout={'fill'}
-                          objectFit={'contain'}
-                          alt={'Fehler beim darstellen der Karte (horizontal)'}
-                        />
-                      </div>
-                    )}
-                    <FormControl>
-                      <Label>
-                        <LabelText>Hintergrundfarbe</LabelText>
-                      </Label>
-                      <Input
-                        type={'color'}
-                        disabled={horizontalImage == undefined}
-                        value={horizontalImageColor}
-                        onChange={(event) => {
-                          setHorizontalImageColor(event.target.value);
-                        }}
-                        className={'w-full'}
-                      />
-                    </FormControl>
-                  </>
-                )}
+            {signageLoading ? (
+              <div className="flex w-full flex-col items-center justify-center gap-2">
+                <UiLoading />
+                <div>Lade Einstellungen...</div>
               </div>
-
-              <div className={'flex flex-col gap-2'}>
-                <div>Vertikal</div>
-                {signageLoading ? (
-                  <div className={'justify-center-center flex w-full flex-col items-center gap-2'}>
-                    <UiLoading />
-                    <div>Lade Einstellungen...</div>
-                  </div>
-                ) : (
-                  <>
-                    {verticalImage == undefined ? (
-                      <UploadDropZone
-                        maxUploadSize={'1MB'}
-                        onSelectedFilesChanged={async (file) => {
-                          if (file) {
-                            const compressedImageFile = await compressFile(file);
-                            const base = await convertToBase64(compressedImageFile);
-                            setVerticalImage(base);
-                          } else {
-                            alertService.error('Datei konnte nicht ausgewählt werden.');
-                          }
-                        }}
-                      />
-                    ) : (
-                      <div className={'relative h-full min-h-40'}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          shape="square"
-                          size="sm"
-                          className="absolute top-2 right-2 z-10 border-error text-error hover:bg-error/10"
-                          onClick={() =>
-                            modalContext.openModal(
-                              <DeleteConfirmationModal spelling={'REMOVE'} entityName={'das Bild'} onApprove={async () => setVerticalImage(undefined)} />,
-                            )
-                          }
-                        >
-                          <FaTrashAlt />
-                        </Button>
-                        <Image
-                          className={'rounded-lg'}
-                          src={verticalImage}
-                          layout={'fill'}
-                          objectFit={'contain'}
-                          alt={'Fehler beim darstellen der Karte (vertikal)'}
-                        />
-                      </div>
-                    )}
-                    <FormControl>
-                      <Label>
-                        <LabelText>Hintergrundfarbe</LabelText>
-                      </Label>
-                      <Input
-                        type={'color'}
-                        disabled={verticalImage == undefined}
-                        value={verticalImageColor}
-                        onChange={(event) => {
-                          setVerticalImageColor(event.target.value);
-                        }}
-                        className={'w-full'}
-                      />
-                    </FormControl>
-                  </>
-                )}
+            ) : (
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <SignageFormatEditor
+                  title="Horizontal"
+                  workspaceId={workspaceId as string}
+                  format={MonitorFormat.LANDSCAPE}
+                  state={landscape}
+                  sourceSlides={portrait.slides}
+                  uploading={landscapeUploading}
+                  selectedIds={landscapeSelectedIds}
+                  filter={landscapeFilter}
+                  onStateChange={setLandscape}
+                  onFilesSelected={(files) => uploadSlides(files, MonitorFormat.LANDSCAPE, setLandscapeUploading, setLandscape)}
+                  onToggleSelect={(slideId) => toggleSelection(setLandscapeSelectedIds, slideId)}
+                  onToggleSelectAll={(slideIds) => toggleSelectAll(setLandscapeSelectedIds, slideIds)}
+                  onFilterChange={setLandscapeFilter}
+                  onClearSelection={() => setLandscapeSelectedIds(new Set())}
+                  onMirrorChange={(mirrorSourceFormat) => handleMirrorChange(MonitorFormat.LANDSCAPE, landscape, setLandscape, mirrorSourceFormat)}
+                />
+                <SignageFormatEditor
+                  title="Vertikal"
+                  workspaceId={workspaceId as string}
+                  format={MonitorFormat.PORTRAIT}
+                  state={portrait}
+                  sourceSlides={landscape.slides}
+                  uploading={portraitUploading}
+                  selectedIds={portraitSelectedIds}
+                  filter={portraitFilter}
+                  onStateChange={setPortrait}
+                  onFilesSelected={(files) => uploadSlides(files, MonitorFormat.PORTRAIT, setPortraitUploading, setPortrait)}
+                  onToggleSelect={(slideId) => toggleSelection(setPortraitSelectedIds, slideId)}
+                  onToggleSelectAll={(slideIds) => toggleSelectAll(setPortraitSelectedIds, slideIds)}
+                  onFilterChange={setPortraitFilter}
+                  onClearSelection={() => setPortraitSelectedIds(new Set())}
+                  onMirrorChange={(mirrorSourceFormat) => handleMirrorChange(MonitorFormat.PORTRAIT, portrait, setPortrait, mirrorSourceFormat)}
+                />
               </div>
-            </div>
+            )}
             <Button type="button" variant="primary" disabled={updatingSignage || signageLoading} onClick={handleUpdateSignage}>
               {updatingSignage ? <UiLoading size="sm" /> : null}
-              Speichern
+              Reihenfolge und Anzeigedauer speichern
             </Button>
           </CardBody>
         </Card>
-      ) : (
-        <></>
-      )}
+      ) : null}
     </ManageEntityLayout>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      pdfjs-dist:
+        specifier: ^6.1.200
+        version: 6.1.200
       pg:
         specifier: ^8.20.0
         version: 8.22.0
@@ -1045,6 +1048,81 @@ packages:
 
   '@mongodb-js/saslprep@1.4.12':
     resolution: {integrity: sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==}
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3902,6 +3980,10 @@ packages:
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -5645,6 +5727,54 @@ snapshots:
   '@mongodb-js/saslprep@1.4.12':
     dependencies:
       sparse-bitfield: 3.0.3
+    optional: true
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -8702,6 +8832,10 @@ snapshots:
       '@pdf-lib/upng': 1.0.1
       pako: 1.0.11
       tslib: 1.14.1
+
+  pdfjs-dist@6.1.200:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.2
 
   perfect-debounce@2.1.0: {}
 

--- a/prisma/migrations/20260703172541_add_signage_slides/migration.sql
+++ b/prisma/migrations/20260703172541_add_signage_slides/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `content` on the `Signage` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Signage" DROP COLUMN "content",
+ADD COLUMN     "slideDurationSeconds" INTEGER NOT NULL DEFAULT 10;
+
+-- CreateTable
+CREATE TABLE "SignageSlide" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "format" "MonitorFormat" NOT NULL,
+    "content" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "SignageSlide_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SignageSlide_workspaceId_format_order_idx" ON "SignageSlide"("workspaceId", "format", "order");
+
+-- AddForeignKey
+ALTER TABLE "SignageSlide" ADD CONSTRAINT "SignageSlide_workspaceId_format_fkey" FOREIGN KEY ("workspaceId", "format") REFERENCES "Signage"("workspaceId", "format") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260704084736_add_signage_slide_scheduling/migration.sql
+++ b/prisma/migrations/20260704084736_add_signage_slide_scheduling/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "SignageSlide" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "validFrom" DATE,
+ADD COLUMN     "validTo" DATE,
+ADD COLUMN     "weekdays" INTEGER[];

--- a/prisma/migrations/20260704091045_add_signage_mirror_and_exclusive/migration.sql
+++ b/prisma/migrations/20260704091045_add_signage_mirror_and_exclusive/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Signage" ADD COLUMN     "mirrorSourceFormat" "MonitorFormat";
+
+-- AlterTable
+ALTER TABLE "SignageSlide" ADD COLUMN     "dateExclusive" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260704095938_add_signage_background_mode/migration.sql
+++ b/prisma/migrations/20260704095938_add_signage_background_mode/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "SignageBackgroundMode" AS ENUM ('COLOR', 'BLURRED');
+
+-- AlterTable
+ALTER TABLE "Signage" ADD COLUMN     "backgroundMode" "SignageBackgroundMode" NOT NULL DEFAULT 'COLOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -165,6 +165,11 @@ enum MonitorFormat {
   PORTRAIT
 }
 
+enum SignageBackgroundMode {
+  COLOR
+  BLURRED
+}
+
 model WorkspaceUser {
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   workspaceId String // relation scalar field (used in the `@relation` attribute above)
@@ -210,13 +215,32 @@ model Workspace {
 }
 
 model Signage {
-  workspace       Workspace     @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  workspaceId     String
-  format          MonitorFormat
-  content         String
-  backgroundColor String?
+  workspace            Workspace             @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  workspaceId          String
+  format               MonitorFormat
+  backgroundColor      String?
+  backgroundMode       SignageBackgroundMode @default(COLOR)
+  slideDurationSeconds Int                   @default(10)
+  mirrorSourceFormat   MonitorFormat?
+  slides               SignageSlide[]
 
   @@id([workspaceId, format])
+}
+
+model SignageSlide {
+  id            String        @id @default(cuid())
+  workspaceId   String
+  format        MonitorFormat
+  content       String
+  order         Int
+  enabled       Boolean       @default(true)
+  weekdays      Int[]
+  validFrom     DateTime?     @db.Date
+  validTo       DateTime?     @db.Date
+  dateExclusive Boolean       @default(false)
+  signage       Signage       @relation(fields: [workspaceId, format], references: [workspaceId, format], onDelete: Cascade)
+
+  @@index([workspaceId, format, order])
 }
 
 model Glass {


### PR DESCRIPTION
## Closing issues:

- Closes #1124

## Before you mark this PR as ready, please check the following points

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I've created all necessary migrations?
- [x] The format is correct (`pnpm format:check`, if invalid `pnpm format:fix`)
- [x] No build errors (`pnpm build`)
- [x] I've tested the implemented function by my own
- [x] Ensure the pr title fits the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) standard

## Bug fix (Issue #1124)

### Have you checked, if there already is any existing issue mentioning the same problem?

- [x] I have searched the existing issues and nothing seems to be related to my problem.

### Environment and Version

v1.20.6 (Local)

### What browsers are you seeing the problem on?

Safari, Chrome, Firefox

### Current Behavior (before this PR)

Uploading PDFs as screen content for the monitor was not possible. Only a single static image per format was supported; multi-image uploads were not available.

### Expected Behavior

Upload PDFs, split each page into slides, and display each page for a configurable duration. Support multiple photo uploads and manage several slides (ordering, scheduling, preview) from the monitor admin UI.

### Anything else?

Builds on the monitor admin and signage API work from #1209 (API key permissions for monitor endpoints).

## Describe your work, what changed

- Introduced `SignageSlide` (Prisma) with slide ordering, per-slide duration, scheduling (start/end), mirror/exclusive flags, and background display modes; added migrations under `prisma/migrations/20260703*` / `20260704*`.
- Added `pdfjs-dist` and `lib/pdf/pdfToImages.ts` to render PDF pages as images when uploading monitor content.
- Extended `UploadDropZone` for multi-file selection, configurable accept types, labels, and hints.
- New signage UI: `SignageSlideList`, `SignageSlideDisplay`, `SignageMonitorPreview`, filters, and bulk actions; reworked workspace **Manage → Monitor** page for slide-based management.
- New admin APIs: `GET/POST` on `/api/workspaces/{workspaceId}/admin/signage/slides` and `PATCH/DELETE` on `.../slides/{slideId}`; updated public `/api/signage/{id}` and legacy admin signage handler for slide playback.
- Signage helpers: active-now filtering, exclusive overlap validation, file processing, and background styling utilities under `lib/signage/`.
- Backup export/import: include signage slides in backup structure; fix workspace import mapping for `UnitConversion` (and related backup consistency updates in `backupStructure.ts` / `import.tsx`).

## Affected sites (please check during review):

- [ ] Workspace **Manage → Monitor** (upload PDF/images, slide list, scheduling, preview)
- [ ] Public signage page `/signage` and display endpoint `/api/signage/{id}`
- [ ] `GET/POST /api/workspaces/{workspaceId}/admin/signage/slides`
- [ ] `PATCH/DELETE /api/workspaces/{workspaceId}/admin/signage/slides/{slideId}`
- [ ] Workspace admin backup **export** / **import** (signage slides, unit conversions)
- [ ] API key permission selector (MONITOR permissions used by signage admin routes)

## Further comments

> **Do not merge before [#1209](https://github.com/jo-gross/Cocktail-Manager/pull/1209) is merged.**

This branch is based on `chore/custom-ui` (same stack as #1209, which also waits on #1208). After #1209 lands on `main`, rebase this branch onto `main` (or onto the post-#1209 `main`) so the PR diff focuses on signage/PDF/multi-slide changes. Until then, the diff against `main` also includes the custom UI refactor commits.


Made with [Cursor](https://cursor.com)